### PR TITLE
002 bronze s3 capture: S3 raw capture (bronze prefix) + secure bucket + unit tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@ RESULTS_PER_PAGE=500
 DB_URL=postgresql+psycopg://postgres:localpw@db:5432/usajobs
 
 # Bronze S3 (optional)
-BRONZE_S3_BUCKET=your-bucket
+BRONZE_S3_BUCKET=dev-tasman-task-usajobs
 BRONZE_S3_PREFIX=bronze/usajobs
 
 # Logging

--- a/IMPLEMENTATION_DOC.md
+++ b/IMPLEMENTATION_DOC.md
@@ -13,7 +13,7 @@ Configure the starting state of the repo and setup the environment(s) to support
 - Setup all environment and config files
 - Verify the setup works cohesively
 
-#### Acceptance criteria
+#### Acceptance Criteria
 
 - Repo is ready for *smooth* (I hope) development
 

--- a/infra/terraform/.terraform.lock.hcl
+++ b/infra/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:hd45qFU5cFuJMpFGdUniU9mVIr5LYVWP1uMeunBpYYs=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/terraform/iam_task.tf
+++ b/infra/terraform/iam_task.tf
@@ -1,0 +1,82 @@
+############################################
+# Trust policies (who can assume the roles)
+############################################
+
+# ECS tasks assume both roles
+data "aws_iam_policy_document" "ecs_tasks_trust" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+############################################
+# Execution role (agent-level permissions)
+############################################
+
+resource "aws_iam_role" "ecs_execution_role" {
+  name               = "${var.project}-${var.env}-ecs-exec"
+  assume_role_policy = data.aws_iam_policy_document.ecs_tasks_trust.json
+  tags = { project = var.project, env = var.env }
+}
+
+# Attach AWS managed policy for pulling from ECR, sending logs, etc.
+resource "aws_iam_role_policy_attachment" "ecs_exec_managed" {
+  role       = aws_iam_role.ecs_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+############################################
+# Task role (your app permissions)
+############################################
+
+resource "aws_iam_role" "ecs_task_role" {
+  name               = "${var.project}-${var.env}-ecs-task"
+  assume_role_policy = data.aws_iam_policy_document.ecs_tasks_trust.json
+  tags = { project = var.project, env = var.env }
+}
+
+# S3 Bronze RW policy (bucket-level + object-level statements)
+data "aws_iam_policy_document" "bronze_rw" {
+  # List operations live on the *bucket* ARN
+  statement {
+    sid     = "ListBucket"
+    effect  = "Allow"
+    actions = ["s3:ListBucket", "s3:ListBucketMultipartUploads"]
+    resources = [aws_s3_bucket.bronze.arn]
+    # (optional) scope list to the bronze/ prefix:
+    # condition { test = "StringLike"; variable = "s3:prefix"; values = ["bronze/*"] }
+  }
+
+  # Object IO lives on the *objects* ARN
+  statement {
+    sid     = "ObjectIO"
+    effect  = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:AbortMultipartUpload"
+    ]
+    resources = ["${aws_s3_bucket.bronze.arn}/*"]
+  }
+}
+
+resource "aws_iam_policy" "task_bronze_policy" {
+  name   = "${var.project}-${var.env}-bronze-rw"
+  policy = data.aws_iam_policy_document.bronze_rw.json
+}
+
+resource "aws_iam_role_policy_attachment" "task_attach_bronze" {
+  role       = aws_iam_role.ecs_task_role.name
+  policy_arn = aws_iam_policy.task_bronze_policy.arn
+}
+
+############################################
+# Outputs (use in ECS task definition later)
+############################################
+output "ecs_task_role_arn"      { value = aws_iam_role.ecs_task_role.arn }
+output "ecs_execution_role_arn" { value = aws_iam_role.ecs_execution_role.arn }

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -1,0 +1,4 @@
+
+output "bronze_bucket" {
+    value = aws_s3_bucket.bronze.bucket
+}

--- a/infra/terraform/providers.tf
+++ b/infra/terraform/providers.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  # (optional now) S3 backend for remote state — add later when ready
+  # backend "s3" {
+  #   bucket = "<state-bucket>"
+  #   key    = "tasman/infra/terraform.tfstate"
+  #   region = "eu-west-2"
+  #   # dynamodb_table = "<locks-table>"  # if you enable state locking
+  # }
+}
+
+provider "aws" {
+  region  = var.aws_region
+  # If using a named profile locally:
+  profile = var.aws_profile
+  default_tags {
+    tags = {
+      project = var.project
+      env     = var.env
+    }
+  }
+}

--- a/infra/terraform/s3_bronze.tf
+++ b/infra/terraform/s3_bronze.tf
@@ -24,13 +24,13 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "bronze" {
   }
 }
 
-# Lifecycle: transition raw after 30 days to Glacier Instant Retrieval and expire after 180
+# Lifecycle: transition bronze after 30 days to Glacier Instant Retrieval and expire after 180
 resource "aws_s3_bucket_lifecycle_configuration" "bronze" {
   bucket = aws_s3_bucket.bronze.id
   rule {
-    id     = "raw-transition-and-expire"
+    id     = "bronze-transition-and-expire"
     status = "Enabled"
-    filter { prefix = "raw/" }
+    filter { prefix = "bronze/" }
 
     transition {
       days          = 30

--- a/infra/terraform/s3_bronze.tf
+++ b/infra/terraform/s3_bronze.tf
@@ -1,0 +1,69 @@
+locals {
+    bronze_bucket = coalesce(var.bronze_bucket_name, "${var.env}-${var.project}-usajobs")
+}
+
+resource "aws_s3_bucket" "bronze" {
+  bucket = local.bronze_bucket
+  force_destroy = false
+}
+
+# Block ALL public access
+resource "aws_s3_bucket_public_access_block" "bronze" {
+  bucket                  = aws_s3_bucket.bronze.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# Default encryption (SSE-S3). S3 encrypts new objects by default since Jan 2023.
+resource "aws_s3_bucket_server_side_encryption_configuration" "bronze" {
+  bucket = aws_s3_bucket.bronze.id
+  rule {
+    apply_server_side_encryption_by_default { sse_algorithm = "AES256" }
+  }
+}
+
+# Lifecycle: transition raw after 30 days to Glacier Instant Retrieval and expire after 180
+resource "aws_s3_bucket_lifecycle_configuration" "bronze" {
+  bucket = aws_s3_bucket.bronze.id
+  rule {
+    id     = "raw-transition-and-expire"
+    status = "Enabled"
+    filter { prefix = "raw/" }
+
+    transition {
+      days          = 30
+      storage_class = "GLACIER_IR"
+    }
+
+    expiration { days = 180 }
+  }
+}
+
+# TLS-only access
+data "aws_iam_policy_document" "bronze" {
+  statement {
+    sid    = "DenyInsecureTransport"
+    effect = "Deny"
+    actions = ["s3:*"]
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    resources = [
+      aws_s3_bucket.bronze.arn,
+      "${aws_s3_bucket.bronze.arn}/*"
+    ]
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "bronze" {
+  bucket = aws_s3_bucket.bronze.id
+  policy = data.aws_iam_policy_document.bronze.json
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -12,5 +12,5 @@ variable "env" {
 variable "bronze_bucket_name" {
   description = "The name of the S3 bucket for bronze data"
   type        = string
-  default     = nuill
+  default     = null
 }

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -1,0 +1,16 @@
+
+variable "project" {
+  description = "The name of the project"
+  type        = string
+}
+
+variable "env" {
+  description = "The environment (e.g. dev, staging, prod)"
+  type        = string
+}
+
+variable "bronze_bucket_name" {
+  description = "The name of the S3 bucket for bronze data"
+  type        = string
+  default     = nuill
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -1,3 +1,14 @@
+variable "aws_region" {
+  description = "The AWS region to deploy resources"
+  type        = string
+  default     = "eu-west-2"
+}
+
+variable "aws_profile" {
+  description = "The AWS profile to use"
+  type        = string
+  default     = "tasman-dev"
+}
 
 variable "project" {
   description = "The name of the project"

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -13,11 +13,13 @@ variable "aws_profile" {
 variable "project" {
   description = "The name of the project"
   type        = string
+  default     = "tasman-task"
 }
 
 variable "env" {
   description = "The environment (e.g. dev, staging, prod)"
   type        = string
+  default     = "dev"
 }
 
 variable "bronze_bucket_name" {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ line-length = 100
 
 [tool.ruff.lint]
 select = ["E","F","I","B","UP","PIE","C4","SIM"]
+ignore = ["UP038"]
 
 [tool.mypy]
 python_version = "3.11"

--- a/src/tasman_etl/runner/run.py
+++ b/src/tasman_etl/runner/run.py
@@ -1,0 +1,26 @@
+from tasman_etl.storage.bronze_s3 import bronze_key, put_json_gz, utc_now_iso
+
+
+def persist_raw_page(run_id: str, page: int, request_dict: dict, response_dict: dict) -> str:
+    """
+    Persist a raw page of data to S3.
+
+    :param run_id: The ID of the run.
+    :param page: The page number.
+    :param request_dict: The request metadata.
+    :param response_dict: The response payload.
+    :return: The S3 key for the bronze job.
+    """
+    envelope = {
+        "request": {**request_dict, "sent_at": request_dict.get("sent_at", utc_now_iso())},
+        "response": {
+            "status": response_dict.get("status", 200),
+            "headers": response_dict.get("headers", {}),
+            "received_at": utc_now_iso(),
+            "payload": response_dict["payload"],
+        },
+        "ingest": {"ingest_run_id": run_id},
+    }
+    key = bronze_key(run_id, page)
+    put_json_gz(key, envelope)
+    return key

--- a/src/tasman_etl/storage/bronze_s3.py
+++ b/src/tasman_etl/storage/bronze_s3.py
@@ -1,0 +1,95 @@
+"""
+This module provides utilities for interacting with AWS S3, specifically for uploading
+gzipped JSON documents to a "bronze" storage layer.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import gzip
+import hashlib
+import io
+import json
+import os
+from collections.abc import Mapping
+from typing import Any
+
+import boto3
+from botocore.config import Config
+
+BRONZE_BUCKET = os.environ["BRONZE_S3_BUCKET"]
+BRONZE_PREFIX = os.environ.get("BRONZE_S3_PREFIX", "bronze/usajobs").rstrip("/")
+
+
+def s3_client():
+    """
+    A boto3 S3 client with custom configuration.
+    """
+    return boto3.client(
+        "s3",
+        config=Config(
+            retries={
+                "max_attempts": 5,
+                "mode": "standard",
+            },  # Configure retry behaviour with exponential backoff
+            user_agent_extra="tasman-etl/bronze",
+        ),
+    )
+
+
+def utc_now_iso() -> str:
+    """
+    Get the current UTC time in ISO 8601 format.
+
+    :return: The current UTC time in ISO 8601 format.
+    """
+    return dt.datetime.now(dt.UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def bronze_key(run_id: str, page: int, date: dt.date | None = None) -> str:
+    """
+    Get the S3 key for a bronze job.
+
+    :param run_id: The ID of the run.
+    :param page: The page number.
+    :param date: The date of the job.
+    :return: The S3 key for the bronze job.
+    """
+    d = date or dt.date.today()
+    return f"{BRONZE_PREFIX}/date={d:%Y/%m/%d}/run={run_id}/page={page:04d}.json.gz"
+
+
+def _to_gz_bytes(doc: Mapping[str, Any]) -> bytes:
+    """
+    Convert a document to gzipped JSON bytes.
+
+    :param doc: The document to convert.
+    :return: The gzipped JSON bytes.
+    """
+    raw = json.dumps(doc, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    buf = io.BytesIO()
+    with gzip.GzipFile(fileobj=buf, mode="wb", mtime=0) as gz:
+        gz.write(raw)
+    return buf.getvalue()
+
+
+def put_json_gz(key: str, doc: Mapping[str, Any]) -> dict:
+    """
+    Upload a gzipped JSON document to S3.
+
+    :param key: The S3 key for the object.
+    :param doc: The document to upload.
+    :return: The response from the S3 put_object call.
+    """
+    body = _to_gz_bytes(doc)
+    sha256_hex = hashlib.sha256(body).hexdigest()
+    return s3_client().put_object(
+        Bucket=BRONZE_BUCKET,
+        Key=key,
+        Body=body,
+        ContentType="application/json",
+        ContentEncoding="gzip",
+        ChecksumAlgorithm="SHA256",  # S3 verifies checksum on upload
+        Metadata={"sha256_hex": sha256_hex},
+        ServerSideEncryption="AES256",
+    )

--- a/src/tasman_etl/storage/bronze_s3.py
+++ b/src/tasman_etl/storage/bronze_s3.py
@@ -63,6 +63,9 @@ def _to_gz_bytes(doc: Mapping[str, Any]) -> bytes:
     """
     Convert a document to gzipped JSON bytes.
 
+    Note:
+        mtime=0 makes the gzip output deterministic (no timestamp), enabling reproducible builds and
+        stable tests.
     :param doc: The document to convert.
     :return: The gzipped JSON bytes.
     """

--- a/tests/unit/test_bronze_s3.py
+++ b/tests/unit/test_bronze_s3.py
@@ -50,7 +50,7 @@ def test_put_json_gz_parameters(monkeypatch, bronze_env):
     captured = {}
 
     class FakeS3:
-        def put_object(self, **kwargs):  # noqa: D401 - simple capture
+        def put_object(self, **kwargs):
             captured.update(kwargs)
             return {"ETag": '"deadbeef"'}
 

--- a/tests/unit/test_bronze_s3.py
+++ b/tests/unit/test_bronze_s3.py
@@ -1,0 +1,91 @@
+import datetime as dt
+import gzip
+import hashlib
+import importlib
+import json
+from types import ModuleType
+
+import pytest
+import tasman_etl.storage.bronze_s3 as bronze_s3
+
+
+@pytest.fixture()
+def bronze_env(monkeypatch) -> ModuleType:
+    """Set required env vars and reload the module so globals pick them up."""
+    monkeypatch.setenv("BRONZE_S3_BUCKET", "unit-test-bucket")
+    # Provide a custom prefix with trailing slash to test rstrip behaviour
+    monkeypatch.setenv("BRONZE_S3_PREFIX", "bronze/custom/")
+    # Import / reload module after env vars set
+
+    importlib.reload(bronze_s3)
+    return bronze_s3
+
+
+def test_bronze_key_with_explicit_date(bronze_env):
+    d = dt.date(2025, 8, 19)
+    key = bronze_env.bronze_key("RUN123", 7, date=d)
+    assert key.startswith("bronze/custom/date=2025/08/19/run=RUN123/")
+    assert key.endswith("page=0007.json.gz")
+
+
+def test_bronze_key_defaults_today(monkeypatch, bronze_env):
+    fake_today = dt.date(2030, 1, 2)
+    monkeypatch.setattr(
+        bronze_env.dt, "date", type("_D", (), {"today": staticmethod(lambda: fake_today)})()
+    )
+    key = bronze_env.bronze_key("RID", 1)
+    assert "date=2030/01/02" in key
+
+
+def test_to_gz_bytes_roundtrip(bronze_env):
+    doc = {"a": 1, "b": "unicodé"}
+    gz_bytes = bronze_env._to_gz_bytes(doc)
+    # Decompress and compare JSON object
+    decompressed = gzip.decompress(gz_bytes).decode("utf-8")
+    # Ensure it is minified (no spaces) due to separators setting
+    assert decompressed == json.dumps(doc, separators=(",", ":"), ensure_ascii=False)
+
+
+def test_put_json_gz_parameters(monkeypatch, bronze_env):
+    captured = {}
+
+    class FakeS3:
+        def put_object(self, **kwargs):  # noqa: D401 - simple capture
+            captured.update(kwargs)
+            return {"ETag": '"deadbeef"'}
+
+    monkeypatch.setattr(bronze_env, "s3_client", lambda: FakeS3())
+    doc = {"x": 42}
+    key = bronze_env.bronze_key("RUNID", 12, date=dt.date(2024, 5, 6))
+    resp = bronze_env.put_json_gz(key, doc)
+    assert resp["ETag"] == '"deadbeef"'
+    # Bucket / Key
+    assert captured["Bucket"] == "unit-test-bucket"
+    assert captured["Key"] == key
+    # Gzip content & checksum
+    body = captured["Body"]
+    assert isinstance(body, (bytes, bytearray))
+    raw = gzip.decompress(body).decode()
+    assert json.loads(raw) == doc
+    expected_sha = hashlib.sha256(body).hexdigest()
+    assert captured["Metadata"]["sha256_hex"] == expected_sha
+    # Content type & encoding
+    assert captured["ContentType"] == "application/json"
+    assert captured["ContentEncoding"] == "gzip"
+    assert captured["ChecksumAlgorithm"] == "SHA256"
+    assert captured["ServerSideEncryption"] == "AES256"
+
+
+def test_utc_now_iso_format(bronze_env):
+    ts = bronze_env.utc_now_iso()
+    # Basic shape: 2025-08-19T12:34:56.123456Z
+    assert ts.endswith("Z")
+    prefix, z = ts[:-1], ts[-1]
+    assert z == "Z"
+    # Microseconds present
+    date_part, time_part = prefix.split("T")
+    assert len(time_part.split(".")) == 2
+    # Parse (allow variable microsecond precision trimming trailing zeros)
+    from datetime import datetime
+
+    datetime.strptime(prefix, "%Y-%m-%dT%H:%M:%S.%f")


### PR DESCRIPTION
### Summary

Introduce **Bronze Capture** for USAJOBS responses under the **`bronze/`** prefix:

* Secure S3 bucket (public access block, SSE-S3, TLS-only) with lifecycle
* Idempotent, gzipped JSON envelopes per page (`date=/run=/page=`), with **SHA-256 checksum verification**
* Unit tests for the Bronze writer and a small runner helper

### Changes

* **Terraform**

  * `s3_bronze.tf`: S3 bucket with **public access block**, **default encryption (SSE-S3)**, **TLS-only** bucket policy, and lifecycle (**transition at 30 days → Glacier Instant Retrieval; expire at 180 days**) scoped to the **`bronze/`** prefix.
  * `iam_task.tf`: distinct **execution role** (AWS managed policy for ECS tasks) and **task role** (S3 permissions). Task policy grants:

    * Bucket-level: `s3:ListBucket`, `s3:ListBucketMultipartUploads` on the bucket ARN
    * Object-level: `s3:GetObject`, `s3:PutObject`, `s3:AbortMultipartUpload` on `arn:aws:s3:::<bucket>/*`
* **App**

  * `src/tasman_etl/storage/bronze_s3.py`: Bronze writer that builds keys
    `bronze/usajobs/date=YYYY/MM/DD/run=<RUN>/page=<NNNN>.json.gz`, gzips payload, and uploads with `ChecksumAlgorithm="SHA256"`.
  * `src/tasman_etl/runner/run.py`: `persist_raw_page(...)` helper that envelopes request/response and calls the Bronze writer.
* **Config**

  * `.env.example`: add `BRONZE_S3_BUCKET` and `BRONZE_S3_PREFIX=bronze/usajobs` (default).
* **Tests**

  * `tests/unit/test_bronze_s3.py`: Moto-backed round-trip (put → get → gunzip → JSON) asserting headers and body.

### How to test locally

```bash
# 1) Infra
cd infra/terraform
terraform apply -var 'project=tasman-task' -var 'env=dev'
# Copy output bucket name into your .env as BRONZE_S3_BUCKET
# Ensure BRONZE_S3_PREFIX=bronze/usajobs

# 2) Python deps / hooks
pip install -e ".[dev]" && pre-commit install

# 3) Unit tests
python -m pytest -q
```

### Notes for reviewers

* Lifecycle filter is set to the **`bronze/`** prefix to match the object keys produced by the writer.
* The bucket blocks public access, enforces TLS-only, and uses SSE-S3 default encryption.
* S3 scales by prefix; the `date=/run=` hierarchy prepares clean partitioning and parallelisation.

### Acceptance checklist

* [ ] Objects appear at `bronze/usajobs/date=YYYY/MM/DD/run=<RUN>/page=<NNNN>.json.gz`
* [ ] `ContentEncoding=gzip`, `ContentType=application/json`
* [ ] S3 object shows a stored checksum; uploads use `ChecksumAlgorithm=SHA256`
* [ ] Lifecycle rule visible and attached to `bronze/` prefix
* [ ] Unit tests passing