### PR TITLE
add Pydantic v2 API models + Silver DTOs and normaliser

### DIFF
--- a/src/tasman_etl/models.py
+++ b/src/tasman_etl/models.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from datetime import datetime
 from typing import Any, cast
 
@@ -87,8 +86,7 @@ class ApiPositionRemuneration(BaseModel):
             return v
         try:
             return int(float(v))
-        except ValueError as e:
-            logging.error(f"Error converting pay range to int: {e}")
+        except ValueError:
             raise
 
 
@@ -448,7 +446,7 @@ def normalise_item(
         telework_eligible=(details.TeleworkEligible if details else None),
         source_event_time=source_event_time,
         ingest_run_id=ingest_run_id,
-        raw_json=item.model_dump(),  # JSONB friendly dict
+        raw_json=item.model_dump(mode="json"),  # JSONB friendly dict
     )
 
     jd = JobDetailsRecord(

--- a/src/tasman_etl/models.py
+++ b/src/tasman_etl/models.py
@@ -446,7 +446,7 @@ def normalise_item(
         telework_eligible=(details.TeleworkEligible if details else None),
         source_event_time=source_event_time,
         ingest_run_id=ingest_run_id,
-        raw_json=item.model_dump(mode="json"),  # JSONB friendly dict
+        raw_json=item.model_dump(mode="json"),  # JSONB serialise-able
     )
 
     jd = JobDetailsRecord(

--- a/src/tasman_etl/models.py
+++ b/src/tasman_etl/models.py
@@ -208,3 +208,23 @@ class ApiMatchedObjectDescriptor(BaseModel):
             return None
         d = self.UserArea.get("Details")
         return ApiDetails.model_validate(d) if isinstance(d, dict) else None
+
+
+class ApiSearchResultItem(BaseModel):
+    model_config = _BASE_CONFIG
+    MatchedObjectId: str | None = None
+    MatchedObjectDescriptor: ApiMatchedObjectDescriptor
+
+
+class ApiSearchResult(BaseModel):
+    model_config = _BASE_CONFIG
+    SearchResultCount: int
+    SearchResultCountAll: int
+    SearchResultItems: list[ApiSearchResultItem]
+
+
+class ApiResponse(BaseModel):
+    model_config = _BASE_CONFIG
+    LanguageCode: str | None = None
+    SearchParameters: dict | None = None
+    SearchResult: ApiSearchResult

--- a/src/tasman_etl/models.py
+++ b/src/tasman_etl/models.py
@@ -406,12 +406,12 @@ def normalise_item(
     list[JobGradeRecord],
 ]:
     """
-    Normalize the API item into the internal data model.
+    Normalise the API item into the internal data model.
 
-    :param item: The API item to normalize.
+    :param item: The API item to normalise.
     :param ingest_run_id: The ID of the ingest run.
     :param source_event_time: The source event time.
-    :return: A tuple containing the normalized job records.
+    :return: A tuple containing the normalised job records.
     """
     d = item.MatchedObjectDescriptor
     # mypy: d.details is a computed_field+property (Pydantic) but static type seen as

--- a/src/tasman_etl/models.py
+++ b/src/tasman_etl/models.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+# ---- Pydantic config notes ----
+# - Strip whitespace, ignore unknown fields (forward-compatible),
+#   use coercion where sensible. Apply stricter rules selectively.
+_BASE_CONFIG = ConfigDict(extra="ignore", str_strip_whitespace=True)
+
+# ------------------------------
+# RAW API SHAPES (subset)
+# ------------------------------
+
+
+class ApiPositionLocation(BaseModel):
+    """
+    Represents a job location from the API.
+    """
+
+    model_config = _BASE_CONFIG
+    LocationName: str | None = None
+    CountryCode: str | None = None
+    CountrySubDivisionCode: str | None = None
+    CityName: str | None = None
+    Longitude: float | None = None
+    Latitude: float | None = None
+
+
+class ApiJobCategory(BaseModel):
+    """
+    Represents a job category from the API.
+    """
+
+    model_config = _BASE_CONFIG
+    Name: str | None = None
+    Code: str
+
+
+class ApiJobGrade(BaseModel):
+    """
+    Represents a job grade from the API.
+    """
+
+    model_config = _BASE_CONFIG
+    Code: str
+
+
+class ApiPositionRemuneration(BaseModel):
+    """
+    Represents a job's remuneration details from the API.
+    """
+
+    model_config = _BASE_CONFIG
+    MinimumRange: int | None = None
+    MaximumRange: int | None = None
+    RateIntervalCode: str | None = None
+    Description: str | None = None
+
+    @field_validator("MinimumRange", "MaximumRange", mode="before")
+    @classmethod
+    def _strip_currency(cls, v: Any) -> Any:
+        """
+        Strip currency symbols and commas from the input string.
+
+        :param v: The input string to process.
+        :return: The processed string without currency symbols and commas.
+        """
+        # Examples: "120,000.00", "$95,000", "95000"
+        if v is None:
+            return None
+        s = str(v).replace("$", "").replace(",", "").strip()
+        return s or None
+
+    @field_validator("MinimumRange", "MaximumRange", mode="after")
+    @classmethod
+    def _to_int(cls, v: int | str | None) -> int | None:
+        """
+        Ensure the value is an integer (after currency stripping).
+        """
+        if v is None:
+            return None
+        if isinstance(v, int):
+            return v
+        try:
+            return int(float(v))
+        except ValueError as e:
+            logging.error(f"Error converting pay range to int: {e}")
+            raise

--- a/src/tasman_etl/models.py
+++ b/src/tasman_etl/models.py
@@ -309,3 +309,47 @@ class JobRecord(BaseModel):
         if v is not None and pay_min is not None and pay_min > v:
             raise ValueError("pay_min cannot exceed pay_max")
         return v
+
+
+class JobDetailsRecord(BaseModel):
+    """
+    Model representing the details of a job in the system.
+    """
+
+    model_config = _BASE_CONFIG
+    job_summary: str | None = None
+    low_grade: str | None = None
+    high_grade: str | None = None
+    promotion_potential: str | None = None
+    organization_codes: str | None = None
+    relocation: str | None = None
+    hiring_path: list[str] = Field(default_factory=list)
+    mco_tags: list[str] = Field(default_factory=list)
+    total_openings: str | None = None
+    agency_marketing_statement: str | None = None
+    travel_code: str | None = None
+    apply_online_url: str | None = None
+    detail_status_url: str | None = None
+    major_duties: str | None = None
+    education: str | None = None
+    requirements: str | None = None
+    evaluations: str | None = None
+    how_to_apply: str | None = None
+    what_to_expect_next: str | None = None
+    required_documents: str | None = None
+    benefits: str | None = None
+    benefits_url: str | None = None
+    benefits_display_default_text: bool | None = None
+    other_information: str | None = None
+    key_requirements: list[str] = Field(default_factory=list)
+    within_area: str | None = None
+    commute_distance: str | None = None
+    service_type: str | None = None
+    announcement_closing_type: str | None = None
+    agency_contact_email: str | None = None
+    security_clearance: str | None = None
+    drug_test_required: bool | None = None
+    position_sensitivity: str | None = None
+    adjudication_type: list[str] = Field(default_factory=list)
+    financial_disclosure: bool | None = None
+    bargaining_unit_status: bool | None = None

--- a/src/tasman_etl/models.py
+++ b/src/tasman_etl/models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator
 
 # ---- Pydantic config notes ----
 # - Strip whitespace, ignore unknown fields (forward-compatible),
@@ -89,3 +89,75 @@ class ApiPositionRemuneration(BaseModel):
         except ValueError as e:
             logging.error(f"Error converting pay range to int: {e}")
             raise
+
+
+class ApiDetails(BaseModel):
+    """
+    USAJOBS 'UserArea.Details' block.
+    Accept both the historic typo and the corrected field name for PositionSensitivity.
+    """
+
+    model_config = ConfigDict(extra="ignore", str_strip_whitespace=True)
+
+    JobSummary: str | None = None
+    LowGrade: str | None = None
+    HighGrade: str | None = None
+    PromotionPotential: str | None = None
+    OrganizationCodes: str | None = None
+    Relocation: str | None = None
+    HiringPath: list[str] | None = None
+    MCOTags: list[str] | None = None
+    TotalOpenings: str | None = None
+    AgencyMarketingStatement: str | None = None
+    TravelCode: str | None = None
+    ApplyOnlineUrl: str | None = None
+    DetailStatusUrl: str | None = None
+    MajorDuties: list[str] | None = None
+    Education: str | None = None
+    Requirements: str | None = None
+    Evaluations: str | None = None
+    HowToApply: str | None = None
+    WhatToExpectNext: str | None = None
+    RequiredDocuments: str | None = None
+    Benefits: str | None = None
+    BenefitsUrl: str | None = None
+    BenefitsDisplayDefaultText: bool | None = None
+    OtherInformation: str | None = None
+    KeyRequirements: list[str] | None = None
+    WithinArea: str | None = None
+    CommuteDistance: str | None = None
+    ServiceType: str | None = None
+    AnnouncementClosingType: str | None = None
+    AgencyContactEmail: str | None = None
+    SecurityClearance: str | None = None
+    DrugTestRequired: bool | None = None
+    # Accept either "PositionSensitivitiy" (historic typo) or "PositionSensitivity".
+    PositionSensitivity: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("PositionSensitivitiy", "PositionSensitivity"),
+    )
+    AdjudicationType: list[str] | None = None
+    TeleworkEligible: bool | None = None
+    RemoteIndicator: bool | None = None
+    FinancialDisclosure: bool | None = None
+    BargainingUnitStatus: bool | None = None
+
+    @field_validator(
+        "DrugTestRequired",
+        "TeleworkEligible",
+        "RemoteIndicator",
+        "FinancialDisclosure",
+        "BenefitsDisplayDefaultText",
+        "BargainingUnitStatus",
+        mode="before",
+    )
+    @classmethod
+    def _yes_no_to_bool(cls, v: Any) -> bool | None:
+        if isinstance(v, bool) or v is None:
+            return v
+        s = str(v).strip().lower()
+        if s in {"yes", "y", "true"}:
+            return True
+        if s in {"no", "n", "false"}:
+            return False
+        return v  # let Pydantic coerce or error

--- a/src/tasman_etl/models.py
+++ b/src/tasman_etl/models.py
@@ -353,3 +353,37 @@ class JobDetailsRecord(BaseModel):
     adjudication_type: list[str] = Field(default_factory=list)
     financial_disclosure: bool | None = None
     bargaining_unit_status: bool | None = None
+
+
+class JobLocationRecord(BaseModel):
+    """
+    Model representing a job location.
+    """
+
+    model_config = _BASE_CONFIG
+    loc_idx: int
+    location_name: str | None = None
+    country_code: str | None = None
+    country_sub_division_code: str | None = None
+    city_name: str | None = None
+    latitude: float | None = None
+    longitude: float | None = None
+
+
+class JobCategoryRecord(BaseModel):
+    """
+    Model representing a job category.
+    """
+
+    model_config = _BASE_CONFIG
+    code: str
+    name: str | None = None
+
+
+class JobGradeRecord(BaseModel):
+    """
+    Model representing a job grade.
+    """
+
+    model_config = _BASE_CONFIG
+    code: str

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from tasman_etl.models import (
+    ApiResponse,
+    ApiSearchResultItem,
+    JobCategoryRecord,
+    JobDetailsRecord,
+    JobGradeRecord,
+    JobLocationRecord,
+    JobRecord,
+    normalise_item,
+)
+
+
+def _single_item(payload: dict) -> ApiSearchResultItem:
+    parsed = ApiResponse.model_validate(payload)
+    return parsed.SearchResult.SearchResultItems[0]
+
+
+def test_normalise_item_happy_path():
+    payload = {
+        "LanguageCode": "EN",
+        "SearchResult": {
+            "SearchResultCount": 1,
+            "SearchResultCountAll": 1,
+            "SearchResultItems": [
+                {
+                    "MatchedObjectId": "123",
+                    "MatchedObjectDescriptor": {
+                        "PositionID": "ABCD-1234",
+                        "PositionTitle": "Data Engineer",
+                        "PositionURI": "https://www.usajobs.gov/job/123",
+                        "ApplyURI": ["https://apply.example/apply"],
+                        "PositionLocationDisplay": "Chicago, IL",
+                        "PositionLocation": [
+                            {
+                                "LocationName": "Chicago, Illinois, United States",
+                                "CountryCode": "US",
+                                "CountrySubDivisionCode": "IL",
+                                "CityName": "Chicago",
+                                "Longitude": -87.6298,
+                                "Latitude": 41.8781,
+                            }
+                        ],
+                        "OrganizationName": "Some Agency",
+                        "DepartmentName": "Dept",
+                        "JobCategory": [{"Name": "IT Mgmt", "Code": "2210"}],
+                        "JobGrade": [{"Code": "GS-13"}],
+                        "QualificationSummary": "Do data stuff.",
+                        "PositionRemuneration": [
+                            {
+                                "MinimumRange": "$95,000",
+                                "MaximumRange": "120,000",
+                                "RateIntervalCode": "PA",
+                            }
+                        ],
+                        "PublicationStartDate": "2025-08-01T00:00:00Z",
+                        "ApplicationCloseDate": "2025-08-31T23:59:59Z",
+                        "UserArea": {
+                            "Details": {
+                                "JobSummary": "Summary",
+                                "DrugTestRequired": "Yes",
+                                "TeleworkEligible": True,
+                                "RemoteIndicator": False,
+                                "MajorDuties": ["A", "B"],
+                            }
+                        },
+                    },
+                }
+            ],
+        },
+    }
+
+    item = _single_item(payload)
+    job, jd, locs, cats, grades = normalise_item(
+        item, ingest_run_id="RID", source_event_time=datetime.now(UTC)
+    )
+
+    assert isinstance(job, JobRecord)
+    assert isinstance(jd, JobDetailsRecord)
+    assert all(isinstance(x, JobLocationRecord) for x in locs)
+    assert all(isinstance(x, JobCategoryRecord) for x in cats)
+    assert all(isinstance(x, JobGradeRecord) for x in grades)
+
+    assert job.position_id == "ABCD-1234"
+    assert job.pay_min == 95000 and job.pay_max == 120000
+    assert job.pay_rate_interval_code == "PA"
+    assert jd.drug_test_required is True
+    assert jd.major_duties == "A; B"
+    assert locs[0].city_name == "Chicago"
+    assert cats[0].code == "2210"
+    assert grades[0].code == "GS-13"
+    # raw_json round trip capture
+    assert job.raw_json["MatchedObjectDescriptor"]["PositionID"] == "ABCD-1234"
+
+
+def test_yes_no_bool_and_alias_position_sensitivity():
+    payload = {
+        "LanguageCode": "EN",
+        "SearchResult": {
+            "SearchResultCount": 1,
+            "SearchResultCountAll": 1,
+            "SearchResultItems": [
+                {
+                    "MatchedObjectId": "999",
+                    "MatchedObjectDescriptor": {
+                        "PositionID": "WXYZ-0001",
+                        "PositionTitle": "Analyst",
+                        "PositionURI": "https://x/job/999",
+                        "PublicationStartDate": "2025-01-01T00:00:00Z",
+                        "ApplicationCloseDate": "2025-01-02T00:00:00Z",
+                        "UserArea": {
+                            "Details": {
+                                # historic typo alias should map to PositionSensitivity
+                                "PositionSensitivitiy": "High",
+                                "DrugTestRequired": "no",
+                                "RemoteIndicator": "Yes",
+                                "TeleworkEligible": "No",
+                            }
+                        },
+                    },
+                }
+            ],
+        },
+    }
+    item = _single_item(payload)
+    job, jd, *_ = normalise_item(item, "RID2", source_event_time=None)
+
+    # Remote/telework propagate
+    assert job.remote_indicator is True  # RemoteIndicator "Yes"
+    assert job.telework_eligible is False  # TeleworkEligible "No"
+    # Position sensitivity flowed into details record
+    assert jd.position_sensitivity == "High"
+    # DrugTestRequired converted to bool False
+    assert jd.drug_test_required is False
+
+
+def test_missing_userarea_details_graceful():
+    payload = {
+        "LanguageCode": "EN",
+        "SearchResult": {
+            "SearchResultCount": 1,
+            "SearchResultCountAll": 1,
+            "SearchResultItems": [
+                {
+                    "MatchedObjectId": None,
+                    "MatchedObjectDescriptor": {
+                        "PositionID": "NO-DETAILS-1",
+                        "PositionTitle": "Role",
+                        "PositionURI": "https://x/job/1",
+                        # No UserArea at all
+                    },
+                }
+            ],
+        },
+    }
+    item = _single_item(payload)
+    job, jd, locs, cats, grades = normalise_item(item, "RID3", None)
+
+    assert job.remote_indicator is None and job.telework_eligible is None
+    assert jd.major_duties is None
+    assert locs == [] and cats == [] and grades == []
+
+
+def test_currency_and_int_passthrough():
+    # Mixed remuneration forms; first one used
+    payload = {
+        "LanguageCode": "EN",
+        "SearchResult": {
+            "SearchResultCount": 1,
+            "SearchResultCountAll": 1,
+            "SearchResultItems": [
+                {
+                    "MatchedObjectId": "m1",
+                    "MatchedObjectDescriptor": {
+                        "PositionID": "PAY-1",
+                        "PositionTitle": "Engineer",
+                        "PositionURI": "https://x/job/pay",
+                        "PositionRemuneration": [
+                            {
+                                "MinimumRange": 100000,
+                                "MaximumRange": "$150,500",
+                                "RateIntervalCode": "PH",
+                            }
+                        ],
+                    },
+                }
+            ],
+        },
+    }
+    item = _single_item(payload)
+    job, *_ = normalise_item(item, "RID4", None)
+    assert job.pay_min == 100000
+    # 150,500 -> 150500
+    assert job.pay_max == 150500
+    assert job.pay_rate_interval_code == "PH"
+
+
+def test_major_duties_joining_empty_safe():
+    payload = {
+        "LanguageCode": "EN",
+        "SearchResult": {
+            "SearchResultCount": 1,
+            "SearchResultCountAll": 1,
+            "SearchResultItems": [
+                {
+                    "MatchedObjectId": "m2",
+                    "MatchedObjectDescriptor": {
+                        "PositionID": "DUTY-1",
+                        "PositionTitle": "Engineer",
+                        "PositionURI": "https://x/job/duty",
+                        "UserArea": {"Details": {"MajorDuties": []}},
+                    },
+                }
+            ],
+        },
+    }
+    item = _single_item(payload)
+    _, jd, *_ = normalise_item(item, "RID5", None)
+    # Empty list -> None (not blank string)
+    assert jd.major_duties is None


### PR DESCRIPTION
### Summary

Introduce strict-enough validation for USAJOBS responses and normalised Data Transfer Objects (DTOs). Adds coercion for currency/booleans, tolerant parsing for upstream drift, and a minimal `normalise_item` to emit `{job, details, locations, categories, grades}` records. Includes a helper to parse full page JSON.

### Scope

* **Added**

  * `src/tasman_etl/models.py`

    * API models: `ApiResponse`, `ApiSearchResultItem`, `ApiMatchedObjectDescriptor`, `ApiDetails`, etc.
    * DTOs: `JobRecord`, `JobDetailsRecord`, `JobLocationRecord`, `JobCategoryRecord`, `JobGradeRecord`
    * Validators:

      * pay range strings → integers, enforce `pay_min <= pay_max`
      * common “Yes/No” booleans → `bool`
      * tolerate upstream typo via alias for `PositionSensitivity`
    * Helpers:

      * `parse_page_json(json_text: str) -> ApiResponse`
      * `normalise_item(...) -> tuple[JobRecord, JobDetailsRecord, list[JobLocationRecord], list[JobCategoryRecord], list[JobGradeRecord]]`
  * **Tests**

    * `tests/unit/test_models.py` (happy path + edge cases for currency/booleans/aliasing)

* **Updated**

  * None beyond imports where needed (if any).

### Design Notes

* **Boundary validation:** Fail fast on impossible inputs but ignore unknown fields for forward compatibility.
* **Type hygiene:** All DTO fields are strongly typed and map 1:1 to Silver DDL.
* **Pragmatism:** Keep `raw_json` on `JobRecord` for reach-back; strict where it matters (money, dates, booleans), lenient elsewhere.
* **Separation of concerns:** Parsing/normalisation lives here; no I/O or DB logic.

### Trade-offs

* `normalise_item` currently lives in `models.py` for momentum; can be moved to `transform.py` in the next feature if desired.

### Test Plan

* Unit:

  * `python -m pytest -k test_models -q`
* Linters/Types:

  * `make fmt lint type`

### Acceptance

* Parsing a real sample yields DTOs with correct types.
* Currency/boolean coercion works and `pay_min <= pay_max` invariant holds.
* Alias for `PositionSensitivity` is accepted.

### Risks

* Upstream payload drift. Mitigation: `extra="ignore"` and narrow validators.

### Checklist

* [x] Unit tests added and passing
* [x] `ruff`/`black`/`mypy` clean
* [x] `IMPLEMENTATION_DOC.md` updated (section 3)
* [x] No secrets or config changes
* [x] ADRs unchanged