### PR TITLE
006 gx pre load gate: expectations and dq smoke tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,5 +16,8 @@ DB_URL=postgresql+psycopg://postgres:localpw@db:5432/usajobs
 BRONZE_S3_BUCKET=dev-tasman-task-usajobs
 BRONZE_S3_PREFIX=bronze/usajobs
 
+# Data Quality gate
+DQ_ENFORCE=true
+
 # Logging
 LOG_LEVEL=INFO

--- a/DEV_LOG.md
+++ b/DEV_LOG.md
@@ -2,15 +2,37 @@
 
 A diary of the design and development of my solution
 
-## 2025-08-19 - Title
+## 2025-08-19 - ETL Featureset Work
 
 ### Actions
 
-- Description
+- Iterated through a whole bunch of features for the project
+  - [x] starter files & config
+  - [x] bronze capture infra and extraction helpers
+  - [x] initial pydantic validation models
+  - [x] bronze to silver normalisation and transformation
+  - [x] loader with idempotent upserts
+- Next tasks
+  - [x] pre-load gate Great Expectations validation (in progress)
+  - [ ] EventBridge -> ECS RunTask scheduling
+  - [ ] secrets & config
+  - [ ] security & durability (DB and network)
+  - [ ] observability (logs and alarms)
+  - [ ] testing: unit, integration, E2E
+  - [ ] CI/CD with GutHub Actions (*)
+  - [ ] Gold views & serving (*)
+  - [ ] performance & scale hardening (*)
+  - [ ] docs and ADR maintenance
+  - [ ] release & versioning (*)
+
+> [!note]
+>
+> - There's a time constraint on the project so anytthing with "(*)" next to it is of a lower priority tier for the solution, in the context of what's needed to demonstrate a viable E2E solution
+> - Anything asterisked can be spoken about in an interview to explain how I'd do it
 
 ### Notes
 
-- Description
+- Not a lot of sleep over the last 2 days when combining this with life and work responsiblities but nearly ready to deploy
 
 ---
 

--- a/IMPLEMENTATION_DOC.md
+++ b/IMPLEMENTATION_DOC.md
@@ -562,6 +562,8 @@ In my struggles to get the first integration test working, this is what I found:
 - “Please write the SQLAlchemy/psycopg upsert for job with ON CONFLICT and updated_at=now().”
 - "Please give me a quick integration test using `psycopg`"
 
+---
+
 ### 6. **Great Expectations (Pre-load Gate)**
 
 **Overview**  
@@ -581,6 +583,9 @@ Small suite: non-nulls on keys, pay range sanity, URL regex, date ordering, ≥1
 - Keep expectations lean to avoid test brittleness.
 
 #### Notes
+
+> [!caution] 
+> It's important for the functioning of this implementation of the GE suite to note exceed `pandas<2.0` becasue it breaks the `src/tasman_etl/dq/gx/validate.py` module. This has been reflected in `pyproject.toml` but would need further research down the line if pandas needed to be upgraded.
 
 - Started with a normal plug-n-play gx system that I normally follow for a suite but I was lead down a great learning path of the library when trying to tailor my solution to the wider context of this project. I'll have the LLM generate a summary of my findings below
 

--- a/IMPLEMENTATION_DOC.md
+++ b/IMPLEMENTATION_DOC.md
@@ -670,6 +670,14 @@ Summary:
 - For arbitrary iterable you don’t need to preserve: next(iter(x), None) is not None (lazy).
 - Avoid len(list(x))—it’s the most expensive form.
 
+##### DQ smoke harness
+
+YI introduced a tiny “DQ smoke harness” to validate a representative page quickly and visibly:
+
+- A cached Great Expectations context via the public API (`gx.get_context()`), plus idempotent creation/retrieval of a pandas datasource and dataframe asset. This keeps repeated page validations cheap and future-proofs against internal module moves.
+- Expectations cover non-nulls, URL regex, pay bounds, and a Python-side check that at least one location row exists. The validator runs directly against a pandas batch and persists/updates the suite if missing.
+- Additional `dq` and further `smoke` commands in the Makefile to quickly run the gx smoke test. This also allows for further automated smoke testing later
+
 #### LLM Prompts
 
 - “What's wrong with my suite?” - fix linting errors

--- a/IMPLEMENTATION_DOC.md
+++ b/IMPLEMENTATION_DOC.md
@@ -493,7 +493,7 @@ You'll see that I declared the 'Bundle' class with a dataclass decorator of the 
 - Safe to use as a dict key or in a set (hashable by default).
 - Use immutable types (e.g. tuple) to not change inner data.
 
-This is a practice I'll maintain throughout throughout the scriiptsm wherever necessary, for the following reasons:
+This is a practice I'll maintain throughout throughout the scripts wherever necessary, for the following reasons:
 
 - Avoids accidental mutation; objects stay stable after creation.
 - Simplifies reasoning, testing, and debugging (pure transforms).

--- a/IMPLEMENTATION_DOC.md
+++ b/IMPLEMENTATION_DOC.md
@@ -7,6 +7,9 @@
 - I tend to leave more comments in my code than the strategy I’ve taken with this project but it’s for a reason.
   - Considering the extensive breakdown and thought process covered by the design doc, this doc and the docstrings, module summaries, branches and PRs throughout, I don’t think all this code **NEEDS** so many comments for the sake of commenting
   - I’m already trying to provide enough documentation, in and out of the code, to tell the story so I don’t want to add too much bloat to what you read
+- A lot of Python scripts will have `from __future__ import annotations` and that's just to enable postponed evaluation of type annotations
+  - Essentially, all annotations are stored as strings and only resolved when needed (such as by type checkers or tools)
+  - It's especially useful in complex projects, like this, or when using advanced typing features, as it avoids issues with circular imports and allows for more readable type hints
 
 ---
 

--- a/IMPLEMENTATION_DOC.md
+++ b/IMPLEMENTATION_DOC.md
@@ -486,6 +486,25 @@ Pure functions that:
 - (optionally) enrich a couple of coded fields via `CodelistClient`,
 - return row dicts ready for loading.
 
+You'll see that I declared the 'Bundle' class with a dataclass decorator of the parameter `(frozen=True)`. This means:
+
+- You can’t reassign fields after you create the object (trying raises an error)
+- Only the attribute names are locked; if a field holds a list/dict, its contents can still change.
+- Safe to use as a dict key or in a set (hashable by default).
+- Use immutable types (e.g. tuple) to not change inner data.
+
+This is a practice I'll maintain throughout throughout the scriiptsm wherever necessary, for the following reasons:
+
+- Avoids accidental mutation; objects stay stable after creation.
+- Simplifies reasoning, testing, and debugging (pure transforms).
+- Enables safe reuse: hashable for sets/deduplication/cache.
+- Improves data integrity for ETL, idempotent upserts, and DQ checks.
+- Lowers concurrency & side‑effect risks (read‑only objects).
+- Clear audit trail: raw + derived fields can’t drift pre‑load.
+- Easier refactors (value-object semantics).
+- Facilitates deterministic change detection and memoisation.
+- Encourages immutable inner types where needed for full safety.
+
 ##### How this fits the SOLID/DRY plan
 
 - **Pure transforms**: no I/O or DB knowledge in `transform.py`.

--- a/IMPLEMENTATION_DOC.md
+++ b/IMPLEMENTATION_DOC.md
@@ -2,6 +2,14 @@
 
 ## Implementation
 
+### General Overview
+
+- I tend to leave more comments in my code than the strategy I’ve taken with this project but it’s for a reason.
+  - Considering the extensive breakdown and thought process covered by the design doc, this doc and the docstrings, module summaries, branches and PRs throughout, I don’t think all this code **NEEDS** so many comments for the sake of commenting
+  - I’m already trying to provide enough documentation, in and out of the code, to tell the story so I don’t want to add too much bloat to what you read
+
+---
+
 ### 0. Starter Files and Config
 
 **Overview**
@@ -502,7 +510,7 @@ This is a practice I'll maintain throughout throughout the scripts wherever nece
 - Lowers concurrency & side‑effect risks (read‑only objects).
 - Clear audit trail: raw + derived fields can’t drift pre‑load.
 - Easier refactors (value-object semantics).
-- Facilitates deterministic change detection and memoisation.
+- Facilitates deterministic change detection and memoisation. (store results without same computations many times)
 - Encourages immutable inner types where needed for full safety.
 
 ##### How this fits the SOLID/DRY plan

--- a/IMPLEMENTATION_DOC.md
+++ b/IMPLEMENTATION_DOC.md
@@ -561,3 +561,118 @@ In my struggles to get the first integration test working, this is what I found:
 
 - “Please write the SQLAlchemy/psycopg upsert for job with ON CONFLICT and updated_at=now().”
 - "Please give me a quick integration test using `psycopg`"
+
+### 6. **Great Expectations (Pre-load Gate)**
+
+**Overview**  
+Small suite: non-nulls on keys, pay range sanity, URL regex, date ordering, ≥1 location per job. Generates Data Docs for review.
+
+#### Tasks
+
+- Build context in `app/tasman_etl/dq/gx/`; checkpoint before DB write (or right after staging).
+- Wire into `runner`.
+
+#### Acceptance Criteria
+
+- Suite passes locally & in CI; failure blocks load and logs summary.
+
+#### Risks/Trade-offs
+
+- Keep expectations lean to avoid test brittleness.
+
+#### Notes
+
+- Started with a normal plug-n-play gx system that I normally follow for a suite but I was lead down a great learning path of the library when trying to tailor my solution to the wider context of this project. I'll have the LLM generate a summary of my findings below
+
+##### GX public API vs direct factory import (LLM generated)
+
+Pros of public API (import great_expectations as gx; context = gx.get_context()):
+
+- Stability: gx.get_context() is the documented, supported entry point; internal module paths can shift in minor releases.
+- Upgrade resilience: Less likely to break when you bump great-expectations (esp. 0.18 → 0.19+ changes).
+- Maintainability: New contributors instantly recognise the pattern from docs.
+- Deprecation signalling: Public API surfaces warnings earlier; internal imports may bypass helper shims.
+- Easier abstraction: You can wrap gx.get_context() in your own helper for caching/injection in tests.
+- Future modes: Supports keyword args (e.g. mode="ephemeral") without chasing factory signatures.
+
+Cons of public API:
+
+- Slightly broader import (top-level package) versus a targeted function; negligible in practice.
+- Type specificity: Direct factory import sometimes provides clearer types to static analyzers (minor; you can add a cast).
+
+Pros of current direct factory import:
+
+- Explicit: Signals exactly which internal function is used.
+- Marginally minimal import path (very small practical gain).
+- May keep mypy from needing a cast if stubs align (depends on version).
+
+Cons of current approach:
+
+- Relies on internal layout (great_expectations.data_context.data_context.context_factory) that can refactor.
+- Harder for others to map to documentation (cognitive overhead).
+- Risk of silent breakage on library upgrade in a scheduled ECS task (failure mid-run; wastes invocation).
+
+ECS / scheduled EventBridge context:
+
+- Cold start cost: Both approaches pay similar import cost; no material performance difference.
+- Resilience matters more: Scheduled jobs should fail only for real data issues, not library internals moving.
+- Container image longevity: You may upgrade GE less frequently; using public API minimises dormant fragility.
+- Simplified observability: Log messages + warnings are aligned with documented entry points (easier triage).
+
+Recommendation:
+Switch to the public API. Wrap it once so you can cache and mock:
+import great_expectations as gx
+_context = None
+def get_gx_context():
+    global _context
+    if_context is None:
+        _context = gx.get_context()  # optionally mode=\"ephemeral\"
+    return _context
+
+Then call get_gx_context() inside validate_page_jobs. This gives:
+
+- Single place to tweak modes or config directories.
+- Optional caching to avoid repeated initialisation if you validate multiple pages in one run.
+- Clean seam for tests (monkeypatch get_gx_context).
+
+_optional tweak to *has_locations (if desired)*:
+def_has_locations(rows):
+    return next(iter(rows), None) is not None
+
+But leaving it as-is is fine since you pass a list.
+
+Summary: Adopt gx.get_context() via a small wrapper for future-proofing and testability; negligible downside for your ECS workload.
+
+##### `len(list({list_input}))` vs `next(iter({list_input}))` (LLM generated)
+
+Difference when loc_rows is already a list:
+
+- Current code: len(list(loc_rows)) >= 1
+  - list(loc_rows) creates a new list copy (O(n) time, O(n) extra memory).
+  - len(...) then checks size. Wasteful duplication.
+- Lazy check: next(iter(loc_rows), None) is not None
+  - Creates an iterator (O(1)) and fetches one element (O(1)).
+  - No copying; constant extra memory.
+
+Why “perfectly lazy”:
+
+- For a generic iterable (could be a generator), next(iter(...), None) stops after the first element—doesn’t traverse or realise the rest.
+- list(...) forces full materialisation: triggers all iteration side effects, loads everything into memory.
+
+Caveats:
+
+- If loc_rows could be a one-shot iterator you still need that first element later, next() would consume it (you’d lose it). With a list that’s not an issue (lists aren’t consumed).
+- If you always receive a list, simplest is just: return len(loc_rows) > 0 or return bool(loc_rows).
+
+Summary:
+
+- For a list: prefer bool(loc_rows) (fastest, no copy).
+- For arbitrary iterable you don’t need to preserve: next(iter(x), None) is not None (lazy).
+- Avoid len(list(x))—it’s the most expensive form.
+
+#### LLM Prompts
+
+- “What's wrong with my suite?” - fix linting errors
+- "What are the pros and cons of importing the context as the public API versus the approach I've taken here"
+- "What's missing in my transition to the public API?" - trying to avoid linter suppressors and import properly, accounting for edge cases
+- "Computationally, what is the difference between `len(list(loc_rows)) >= 1` and `next(iter(loc_rows), None) is not None` when loc_rows is a list? Also, why is it perfectly lazy to use the latter?"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: fmt lint type unit integration test build up down links db-migrate
+.PHONY: fmt lint type unit integration test build up down links db-migrate dq smoke
 
 fmt:
 	ruff check --select I --fix .
@@ -53,3 +53,11 @@ db-migrate:
 			psql "$(PSQL_URL)" -v ON_ERROR_STOP=1 -f "$$f"; \
 		done; \
 	fi
+
+dq:
+	# Use -s to show GE progress + printed expectation summary
+	python -m pytest -s tests/smoke/test_dq_smoke.py
+
+smoke:
+	# -s disables output capture so GE tqdm progress bars & warnings are visible; remove -q for full detail
+	python -m pytest -s tests/smoke

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: fmt lint type unit integration test build up down links db-migrate dq smoke
+.PHONY: fmt lint type unit integration test build up down links db-migrate dq smoke run
 
 fmt:
 	ruff check --select I --fix .
@@ -61,3 +61,6 @@ dq:
 smoke:
 	# -s disables output capture so GE tqdm progress bars & warnings are visible; remove -q for full detail
 	python -m pytest -s tests/smoke
+
+run:
+	python -m tasman_etl.runner.run

--- a/README.md
+++ b/README.md
@@ -65,10 +65,11 @@ tasman-dataeng-task
 └─ tests
    ├─ integration
    │  └─ test_upsert.py
-   └─ unit
-      ├─ test_models.py
-      └─ test_transform.py
-
+   ├─ unit
+   │  ├─ test_models.py
+   |  └─ test_transform.py
+   └─ smoke
+      └─ test_dq_smoke.py
 ```
 
 ## Quick Start
@@ -76,7 +77,9 @@ tasman-dataeng-task
 ```bash
 make up                   # starts Postgres
 make db-migrate           # applies all SQL migrations
-make test                 # runs tests (which also migrates first)
+make dq                   # runs the targeted DQ smoke test with visible GE output
+make smoke                # runs everything in tests/smoke with -s (no capture)
+make test                 # full suite (lint/type/unit/integration) + db-migrate first
 ```
 
 ## Common Terms

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,9 @@ mypy_path = "$MYPY_CONFIG_FILE_DIR/src"
 
 [tool.pytest.ini_options]
 filterwarnings = [
+  # Suppress known Great Expectations warning about Validator-level `result_format` config not being persisted.
+  # See: https://github.com/great-expectations/great_expectations/issues/7466
+  # This is a temporary workaround until upstream resolves the issue.
   "ignore:`result_format` configured at the Validator-level will not be persisted.:UserWarning",
   "ignore:`Number` field should not be instantiated.*:marshmallow.warnings.ChangedInMarshmallow4Warning",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   "python-dotenv>=1.0",             # local .env dev
   "boto3>=1.34",                    # S3 bronze (optional)
   "great-expectations>=0.18.0",     # data quality gate
+  "pandas>=2.0",
   "typing-extensions>=4.11",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ authors = [{ name = "Ezra Chamba" }]
 dependencies = [
   "requests>=2.32",                 # HTTP client
   "pydantic>=2.7",                  # parse/validate API payloads (v2 validators)
+  "pydantic-settings>=2.0",         # parse/validate config (v2)
   "sqlalchemy>=2.0",                # DB engine / SQL
   "psycopg[binary,pool]>=3.2",      # Postgres driver (v3)
   "tenacity>=8.3",                  # retries w/ backoff+ jitter
@@ -22,7 +23,7 @@ dependencies = [
   "python-dotenv>=1.0",             # local .env dev
   "boto3>=1.34",                    # S3 bronze (optional)
   "great-expectations>=0.18.0",     # data quality gate
-  "pandas>=2.2",
+  "pandas>=1.5,<2.0",
   "typing-extensions>=4.11",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,3 +61,9 @@ python_version = "3.11"
 strict = false
 warn_unused_ignores = true
 mypy_path = "$MYPY_CONFIG_FILE_DIR/src"
+
+[tool.pytest.ini_options]
+filterwarnings = [
+  "ignore:`result_format` configured at the Validator-level will not be persisted.:UserWarning",
+  "ignore:`Number` field should not be instantiated.*:marshmallow.warnings.ChangedInMarshmallow4Warning",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
   "python-dotenv>=1.0",             # local .env dev
   "boto3>=1.34",                    # S3 bronze (optional)
   "great-expectations>=0.18.0",     # data quality gate
-  "pandas>=1.5",
+  "pandas>=2.2",
   "typing-extensions>=4.11",
 ]
 
@@ -67,3 +67,4 @@ filterwarnings = [
   "ignore:`result_format` configured at the Validator-level will not be persisted.:UserWarning",
   "ignore:`Number` field should not be instantiated.*:marshmallow.warnings.ChangedInMarshmallow4Warning",
 ]
+testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
   "python-dotenv>=1.0",             # local .env dev
   "boto3>=1.34",                    # S3 bronze (optional)
   "great-expectations>=0.18.0",     # data quality gate
-  "pandas>=2.0",
+  "pandas>=1.5",
   "typing-extensions>=4.11",
 ]
 

--- a/src/tasman_etl/config.py
+++ b/src/tasman_etl/config.py
@@ -1,0 +1,9 @@
+from pydantic import Field
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    dq_enforce: bool = Field(
+        default=True,
+        validation_alias="DQ_ENFORCE",
+    )

--- a/src/tasman_etl/config.py
+++ b/src/tasman_etl/config.py
@@ -1,9 +1,19 @@
 from pydantic import Field
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
+    # Toggle the Great Expectations Data Quality (DQ) checks
+    # True blocks on failure, False logs and continues
     dq_enforce: bool = Field(
         default=True,
         validation_alias="DQ_ENFORCE",
     )
+    # Database connection string for loader
+    db_url: str = Field(
+        default="postgresql://postgres:localpw@localhost:5432/usajobs",
+        validation_alias="DB_URL",
+    )
+
+    # (Optional) make local .env loading explicit; safe in containers too.
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")

--- a/src/tasman_etl/dq/gx/validate.py
+++ b/src/tasman_etl/dq/gx/validate.py
@@ -137,13 +137,13 @@ def validate_page_jobs(
     if TYPE_CHECKING:
 
         class _PandasDatasource(Protocol):  # pragma: no cover - typing aid
-            def add_dataframe_asset(self, name: str): ...  # noqa: D401
-            def get_asset(self, name: str): ...  # noqa: D401
+            def add_dataframe_asset(self, name: str): ...
+            def get_asset(self, name: str): ...
 
             assets: list[Any]
 
         class _DataFrameAsset(Protocol):  # pragma: no cover - typing aid
-            def add_batch_definition_whole_dataframe(self, name: str): ...  # noqa: D401
+            def add_batch_definition_whole_dataframe(self, name: str): ...
 
             batch_definitions: list[Any]
 

--- a/src/tasman_etl/dq/gx/validate.py
+++ b/src/tasman_etl/dq/gx/validate.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
+import contextlib
 from collections.abc import Iterable
 from dataclasses import dataclass
 
 import pandas as pd
-from tasman_etl.models import (
-    JobRecord,
-)
+from great_expectations.data_context.data_context.context_factory import get_context
+from tasman_etl.models import JobLocationRecord, JobRecord
 
 
 @dataclass(frozen=True)
@@ -68,3 +68,114 @@ def _jobs_dataframe(rows: Iterable[JobRecord]) -> pd.DataFrame:
         }
     )
     return df
+
+
+def _has_locations(loc_rows: Iterable[JobLocationRecord]) -> bool:
+    """
+    Check if there are any location rows present.
+
+    Note:
+      For this pipeline, a page represents one logical set of jobs;
+      we just require at least one location row overall.
+
+    :param loc_rows: The list of JobLocationRecord objects.
+    :return: True if there are location rows, False otherwise.
+    """
+    # Check if there are any location rows present.
+    return len(list(loc_rows)) >= 1
+
+
+def validate_page_jobs(
+    jobs: list[JobRecord],
+    locations: list[JobLocationRecord],
+) -> ValidationResult:
+    """
+    Validate a page of normalised jobs + child rows.
+    Return a ValidationResult with pass/fail and rule outcomes.
+
+    :param jobs: The list of JobRecord objects.
+    :param locations: The list of JobLocationRecord objects.
+    :return: A ValidationResult indicating the outcome of the validation.
+    """
+    rules: list[RuleOutcome] = []
+
+    # Quick Python guard: "≥1 location exists"
+    has_loc = _has_locations(locations)
+    rules.append(RuleOutcome(name="has_at_least_one_location", success=has_loc))
+    if not jobs:
+        rules.append(RuleOutcome(name="non_empty_jobs_page", success=False, details="no jobs"))
+        return ValidationResult(passed=False, rules=rules)
+
+    df = _jobs_dataframe(jobs)
+
+    # Ephemeral GX context / pandas datasource
+    context = get_context()
+    pandas_ds = context.data_sources.add_pandas("pandas_default")
+    asset = pandas_ds.add_dataframe_asset("jobs_asset")
+    batch_def = asset.add_batch_definition_whole_dataframe("whole_df")
+    batch = batch_def.get_batch(batch_parameters={"dataframe": df})
+
+    # Old (causes type complaint):
+    # validator = context.get_validator(batch=batch, expectation_suite_name="jobs_suite")
+
+    # Use the batch_request from the fluent Batch (type-compatible with legacy API)
+    validator = context.get_validator(
+        batch_request=batch.batch_request,  # provides datasource/asset/parameters
+        expectation_suite_name="jobs_suite",
+    )
+    validator.expect_column_values_to_not_be_null("position_id")
+    validator.expect_column_values_to_not_be_null("position_title")
+    validator.expect_column_values_to_match_regex("position_uri", r"^https?://")
+    validator.expect_column_values_to_be_between("pay_min", min_value=0, mostly=1.0)
+    validator.expect_column_values_to_be_between("pay_max", min_value=0, mostly=1.0)
+    validator.expect_column_values_to_be_in_set("apply_uri_ok", value_set=[True])
+    validator.expect_column_values_to_be_in_set("pay_pair_ok", value_set=[True])
+
+    # Run validation directly (no ValidationDefinition / Checkpoint abstraction)
+    suite = validator.get_expectation_suite()
+    # (Optional) persist suite in context if there;s a need to reuse
+    try:
+        context.suites.add_or_update(suite)
+    except AttributeError:
+        # Older versions may use add() then update(); ignore if unsupported
+        contextlib.suppress(AttributeError)
+
+    validation_result = validator.validate()
+    # Help static type checker
+    from great_expectations.core.expectation_validation_result import (
+        ExpectationSuiteValidationResult,
+    )
+
+    assert isinstance(
+        validation_result, ExpectationSuiteValidationResult
+    ), f"Unexpected validation result type: {type(validation_result)}"
+
+    gx_pass = validation_result.success
+    for evr in validation_result.results:
+        cfg = getattr(evr, "expectation_config", None)
+
+        if isinstance(cfg, dict):
+            exp_type = cfg.get("expectation_type") or cfg.get("type") or "<unknown>"
+        else:
+            # ExpectationConfiguration object or None
+            exp_type = (
+                getattr(cfg, "expectation_type", None)
+                or getattr(cfg, "type", None)
+                or type(evr).__name__
+            )
+
+        unexpected = None
+        r = getattr(evr, "result", None)
+        if isinstance(r, dict):
+            unexpected = r.get("unexpected_count")
+
+        rules.append(
+            RuleOutcome(
+                name=exp_type,
+                success=getattr(evr, "success", False),
+                details=None if getattr(evr, "success", False) else str(unexpected),
+            )
+        )
+
+    passed = has_loc and gx_pass
+    return ValidationResult(passed=passed, rules=rules)

--- a/src/tasman_etl/dq/gx/validate.py
+++ b/src/tasman_etl/dq/gx/validate.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+import pandas as pd
+from tasman_etl.models import (
+    JobRecord,
+)
+
+
+@dataclass(frozen=True)
+class RuleOutcome:
+    name: str
+    success: bool
+    details: str | None = None
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    passed: bool
+    rules: list[RuleOutcome]
+
+
+def _jobs_dataframe(rows: Iterable[JobRecord]) -> pd.DataFrame:
+    """
+    Convert a list of JobRecord objects into a Pandas DataFrame.
+
+    :param rows: The list of JobRecord objects.
+    :return: A Pandas DataFrame representing the job records.
+    """
+
+    # Derive a few helper booleans for simpler expectations
+    def url_ok(urls: list[str]) -> bool:
+        """
+        Check if all URLs in the list are valid (i.e., start with http:// or https://).
+
+        :param urls: The list of URLs to check.
+        :return: True if all URLs are valid, False otherwise.
+        """
+        if not urls:
+            return True
+        return all(u.startswith(("http://", "https://")) for u in urls)
+
+    def pay_pair_ok(pmin, pmax) -> bool:
+        """
+        Check if the pay_min and pay_max values are valid.
+
+        :param pmin: The pay_min value.
+        :param pmax: The pay_max value.
+        :return: True if the pay_min is less than or equal to the pay_max, False otherwise.
+        """
+        if pmin is None or pmax is None:
+            return True
+        return pmin <= pmax
+
+    df = pd.DataFrame(
+        {
+            "position_id": [r.position_id for r in rows],
+            "position_title": [r.position_title for r in rows],
+            "position_uri": [r.position_uri for r in rows],
+            "apply_uri_ok": [url_ok(r.apply_uri) for r in rows],
+            "pay_min": [r.pay_min for r in rows],
+            "pay_max": [r.pay_max for r in rows],
+            "pay_pair_ok": [pay_pair_ok(r.pay_min, r.pay_max) for r in rows],
+            "publication_start_date": [r.publication_start_date for r in rows],
+            "application_close_date": [r.application_close_date for r in rows],
+        }
+    )
+    return df

--- a/src/tasman_etl/dq/gx/validate.py
+++ b/src/tasman_etl/dq/gx/validate.py
@@ -83,7 +83,7 @@ def _has_locations(loc_rows: Iterable[JobLocationRecord]) -> bool:
     :return: True if there are location rows, False otherwise.
     """
     # Check if there are any location rows present.
-    return len(list(loc_rows)) >= 1
+    return next(iter(loc_rows), None) is not None
 
 
 # Cached context instance (lazy init); keeps repeated page validations cheap in one run.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+"""Pytest configuration for logging.
+
+Sets up a dedicated logger for smoke (and potentially other) tests so that
+INFO-level summary lines are always emitted without enabling noisy INFO logs
+from third-party libraries.
+"""
+
+from __future__ import annotations
+
+import logging
+
+
+def pytest_configure(config):
+    # Create an isolated logger for our DQ smoke summaries.
+    logger = logging.getLogger("dq.smoke")
+    logger.setLevel(logging.INFO)
+    if not logger.handlers:  # idempotent
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        logger.addHandler(handler)
+        # Prevent double logging via root.
+        logger.propagate = False
+
+    # Optional: if you want automatic CLI logging without -s or explicit flags, uncomment:
+    # config.option.log_cli = True
+    # config.option.log_cli_level = "INFO"

--- a/tests/smoke/test_dq_smoke.py
+++ b/tests/smoke/test_dq_smoke.py
@@ -1,0 +1,58 @@
+"""Great Expectations smoke test.
+
+This is a lightweight end-to-end style check that the validation layer
+can be invoked in a production-like manner and all current expectations pass
+for a minimal, representative job record.
+"""
+
+import logging
+from datetime import UTC, datetime
+
+from tasman_etl.dq.gx.validate import validate_page_jobs
+from tasman_etl.models import JobLocationRecord, JobRecord
+
+
+def test_dq_smoke() -> None:
+    jobs = [
+        JobRecord(
+            position_id="GX-SMOKE-1",
+            position_uri="https://example.com/job/1",
+            position_title="Data Engineer",
+            apply_uri=["https://example.com/apply"],
+            pay_min=90_000,
+            pay_max=120_000,
+            publication_start_date=datetime.now(UTC),
+            raw_json={"smoke": True},
+        )
+    ]
+    locs = [JobLocationRecord(loc_idx=0, city_name="Chicago")]
+
+    res = validate_page_jobs(jobs, locs)
+
+    # Verbose human-readable summary via logging (dq.smoke logger configured in conftest)
+    log = logging.getLogger("dq.smoke")
+    log.info("Great Expectations passed: %s", res.passed)
+    for r in res.rules:
+        status = "OK" if r.success else "FAIL"
+        detail = "" if r.success else f" ({r.details})"
+        log.info("- %s: %s%s", r.name, status, detail)
+
+    # Overall gate should pass
+    assert res.passed, "Smoke validation failed: overall gate did not pass"
+
+    # All individual expectations should have succeeded
+    failed = [r for r in res.rules if not r.success]
+    assert not failed, f"Some expectations failed: {[f.name for f in failed]}"
+
+    # Optional: sanity check on rule names remaining stable (helps detect silent drops)
+    expected_rule_prefixes = {
+        "has_at_least_one_location",
+        "expect_column_values_to_not_be_null",
+        "expect_column_values_to_match_regex",
+        "expect_column_values_to_be_between",
+        "expect_column_values_to_be_in_set",
+    }
+    observed = {r.name for r in res.rules}
+    assert (
+        observed & expected_rule_prefixes
+    ), "Expected at least one known expectation; got none of the expected names"

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from tasman_etl.dq.gx.validate import validate_page_jobs
+from tasman_etl.models import JobLocationRecord, JobRecord
+
+
+def _make_job(
+    position_id: str = "123",
+    position_title: str = "Data Engineer",
+    position_uri: str = "https://example.com/job/123",
+    apply_uri: list[str] | None = None,
+    pay_min: int | None = 100,
+    pay_max: int | None = 200,
+) -> JobRecord:
+    return JobRecord(
+        position_id=position_id,
+        position_title=position_title,
+        position_uri=position_uri,
+        apply_uri=apply_uri or ["https://apply.example.com/123"],
+        pay_min=pay_min,
+        pay_max=pay_max,
+        raw_json={"PositionID": position_id},
+    )
+
+
+def test_validate_happy_path():
+    job = _make_job()
+    loc = JobLocationRecord(loc_idx=0, city_name="Chicago")
+    result = validate_page_jobs([job], [loc])
+
+    # Should pass overall
+    assert result.passed is True
+    # All rules (apart from location guard) should be successful
+    failing = [r for r in result.rules if not r.success]
+    assert not failing, f"Expected no failing rules, got: {failing}"
+    assert any(r.name == "has_at_least_one_location" for r in result.rules)
+
+
+def test_validate_empty_jobs_page_fails():
+    loc = JobLocationRecord(loc_idx=0, city_name="Chicago")
+    result = validate_page_jobs([], [loc])
+    assert result.passed is False
+    # Expect the non_empty_jobs_page rule to be present and failing
+    names = {r.name: r for r in result.rules}
+    assert "non_empty_jobs_page" in names
+    assert names["non_empty_jobs_page"].success is False
+
+
+def test_validate_missing_locations_fails():
+    job = _make_job()
+    result = validate_page_jobs([job], [])
+    assert result.passed is False
+    # Location guard should fail, but expectations should still have run and succeeded
+    loc_rule = next(r for r in result.rules if r.name == "has_at_least_one_location")
+    assert loc_rule.success is False
+    # Ensure at least one expectation rule is present and successful
+    assert any(
+        r.name.startswith("expect_") and r.success for r in result.rules
+    ), "Expectation rules missing or unsuccessful"
+
+
+def test_validate_expectation_failures():
+    # Create a job that will fail several expectations:
+    # - invalid position_uri (regex fail)
+    # - negative pay_min (between fail)
+    # - invalid apply_uri scheme (apply_uri_ok False)
+    job = _make_job(
+        position_id="bad1",
+        position_title="Bad Job",
+        position_uri="ftp://not-http",  # fails regex ^https?://
+        apply_uri=["ftp://apply.invalid/123"],  # url_ok -> False
+        pay_min=-10,  # below 0
+        pay_max=0,
+    )
+    loc = JobLocationRecord(loc_idx=0, city_name="Chicago")
+    result = validate_page_jobs([job], [loc])
+
+    assert result.passed is False
+    failing_expectations = [
+        r for r in result.rules if r.name.startswith("expect_") and not r.success
+    ]
+    # We expect at least two different expectation types to fail (regex + between or in_set)
+    assert len(failing_expectations) >= 2, failing_expectations
+    # Sanity: location rule should succeed
+    loc_rule = next(r for r in result.rules if r.name == "has_at_least_one_location")
+    assert loc_rule.success is True


### PR DESCRIPTION
## Summary

Introduce a lightweight Great Expectations gate before loading to Silver. Adds a cached GE context, a pandas datasource/asset, a small expectation set on the normalised `JobRecord`s, and a smoke test path with visible summaries. Aimed at fast feedback and minimal brittleness.

## What changed

* `src/tasman_etl/dq/gx/validate.py`:

  * Public API context (`gx.get_context()`), cached.
  * Idempotent pandas datasource + dataframe asset wiring.
  * Expectations: non-null keys, URL regex, pay range sanity, pairwise `pay_min <= pay_max`.
  * Returns structured `ValidationResult` with per-rule outcomes.
* `tests/smoke/test_dq_smoke.py`: high-signal smoke covering the current rule set, with readable output.
* `tests/conftest.py`: dedicated `dq.smoke` logger for clean summaries without enabling chatty library logs.
* **Makefile**: `dq` and `smoke` targets for quick runs (uses `-s` so GE’s progress/messages are visible).
* **pyproject.toml**: add `pandas>=2.2`; add `[tool.pytest.ini_options]` with `testpaths=["tests"]`.

## Rationale

* Early, deterministic fail-fast checks catch bad pages before DB writes.
* Public API + cached context reduces flakiness and cost while staying compatible with future GE versions.
* Smoke tests give human-readable feedback in CI and locally without overwhelming logs.

## How to test

* Local: `make dq` (single smoke), `make smoke` (all smoke tests), or `make test` (full).
* CI: same commands; no additional secrets required.

## Acceptance criteria

* DQ smoke passes on a representative job page.
* On failure, rule-by-rule outcomes print in CI logs.
* No required changes to runner yet; this is a drop-in gate callable from orchestration.

## Notes

* Kept the suite intentionally small to avoid brittleness. Easy to extend later (e.g., date order checks).
* The context/asset creation is idempotent so repeated calls in a single run won’t churn state.