### PR TITLE
007 orchestrate and aws scheduling: submission

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@ RADIUS_MILES=50
 RESULTS_PER_PAGE=500
 
 # DB
-DB_URL=postgresql+psycopg://postgres:localpw@db:5432/usajobs
+DB_URL=postgresql://postgres:localpw@db:5432/usajobs
 
 # Bronze S3 (optional)
 BRONZE_S3_BUCKET=dev-tasman-task-usajobs

--- a/IMPLEMENTATION_DOC.md
+++ b/IMPLEMENTATION_DOC.md
@@ -7,6 +7,7 @@
 - I tend to leave more comments in my code than the strategy I’ve taken with this project but it’s for a reason.
   - Considering the extensive breakdown and thought process covered by the design doc, this doc and the docstrings, module summaries, branches and PRs throughout, I don’t think all this code **NEEDS** so many comments for the sake of commenting
   - I’m already trying to provide enough documentation, in and out of the code, to tell the story so I don’t want to add too much bloat to what you read
+  - The cases where there are more comments are probably indicative of my learning by doing. This way when I come back to my code for future work, it clicks again more quickly
 - A lot of Python scripts will have `from __future__ import annotations` and that's just to enable postponed evaluation of type annotations
   - Essentially, all annotations are stored as strings and only resolved when needed (such as by type checkers or tools)
   - It's especially useful in complex projects, like this, or when using advanced typing features, as it avoids issues with circular imports and allows for more readable type hints

--- a/IMPLEMENTATION_DOC.md
+++ b/IMPLEMENTATION_DOC.md
@@ -588,7 +588,7 @@ Small suite: non-nulls on keys, pay range sanity, URL regex, date ordering, ≥1
 
 #### Notes
 
-> [!caution] 
+> [!caution]
 > It's important for the functioning of this implementation of the GE suite to note exceed `pandas<2.0` becasue it breaks the `src/tasman_etl/dq/gx/validate.py` module. This has been reflected in `pyproject.toml` but would need further research down the line if pandas needed to be upgraded.
 
 - Started with a normal plug-n-play gx system that I normally follow for a suite but I was lead down a great learning path of the library when trying to tailor my solution to the wider context of this project. I'll have the LLM generate a summary of my findings below

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,0 +1,198 @@
+# ECS + ECR + EventBridge
+
+
+# ECR Repository
+
+resource "aws_ecr_repository" "etl" {
+	name                 = "${var.project}-${var.env}-etl"
+	image_tag_mutability = "MUTABLE"
+	lifecycle { prevent_destroy = true }
+}
+
+
+# CloudWatch Log Group
+
+resource "aws_cloudwatch_log_group" "etl" {
+	name              = "/ecs/${var.project}-${var.env}-etl"
+	retention_in_days = 30
+}
+
+
+# ECS Cluster
+
+resource "aws_ecs_cluster" "etl" {
+	name = "${var.project}-${var.env}-cluster"
+}
+
+
+# Security Group (egress only) - reuse default VPC discovered implicitly
+
+data "aws_vpc" "default" { default = true }
+data "aws_subnets" "default" {
+	filter {
+		name   = "vpc-id"
+		values = [data.aws_vpc.default.id]
+	}
+}
+
+resource "aws_security_group" "etl_task" {
+	name        = "${var.project}-${var.env}-etl-sg"
+	description = "ECS task egress"
+	vpc_id      = data.aws_vpc.default.id
+
+	egress {
+		from_port   = 0
+		to_port     = 0
+		protocol    = "-1"
+		cidr_blocks = ["0.0.0.0/0"]
+	}
+}
+
+
+# Task Definition (Fargate)
+
+
+locals {
+	# Base environment vars (excluding DB_URL which is conditional)
+	_base_env = [
+		{ name = "USAJOBS_USER_AGENT", value = var.usajobs_user_agent },
+		{ name = "BRONZE_S3_BUCKET",   value = aws_s3_bucket.bronze.bucket },
+		{ name = "BRONZE_S3_PREFIX",   value = var.bronze_prefix },
+		{ name = "DQ_ENFORCE",         value = tostring(var.dq_enforce) },
+		{ name = "KEYWORD",            value = var.keyword },
+		{ name = "LOCATION_NAME",      value = var.location_name },
+		{ name = "MAX_PAGES",          value = tostring(var.max_pages) },
+	]
+
+	# Add DB_URL only when NOT using a secret and a fallback value provided
+	container_env = concat(
+		local._base_env,
+		(var.db_url_secret_name == "" && var.db_url != "") ? [
+			{ name = "DB_URL", value = var.db_url }
+		] : []
+	)
+
+	container_defs = [{
+		name      = "etl"
+		image     = "${aws_ecr_repository.etl.repository_url}:latest"
+		essential = true
+		environment = local.container_env
+		secrets = concat(
+			var.usajobs_auth_secret_name != "" && local.usajobs_auth_secret_arn != "" ? [
+				{
+					name      = "USAJOBS_AUTH_KEY"
+					valueFrom = local.usajobs_auth_secret_arn
+				}
+			] : [],
+			var.db_url_secret_name != "" && local.db_url_secret_arn != "" ? [
+				{
+					name      = "DB_URL"
+					valueFrom = local.db_url_secret_arn
+				}
+			] : []
+		)
+		logConfiguration = {
+			logDriver = "awslogs"
+			options = {
+				awslogs-group         = aws_cloudwatch_log_group.etl.name
+				awslogs-region        = var.aws_region
+				awslogs-stream-prefix = "ecs"
+			}
+		}
+	}]
+}
+
+resource "aws_ecs_task_definition" "etl" {
+	family                   = "${var.project}-${var.env}-etl"
+	cpu                      = tostring(var.container_cpu)
+	memory                   = tostring(var.container_memory)
+	network_mode             = "awsvpc"
+	requires_compatibilities = ["FARGATE"]
+	execution_role_arn       = aws_iam_role.ecs_execution_role.arn
+	task_role_arn            = aws_iam_role.ecs_task_role.arn
+	runtime_platform {
+		operating_system_family = "LINUX"
+		cpu_architecture        = "X86_64"
+	}
+	container_definitions = jsonencode(local.container_defs)
+}
+
+
+# EventBridge Schedule triggering RunTask
+
+resource "aws_cloudwatch_event_rule" "etl_schedule" {
+	name                = "${var.project}-${var.env}-etl-schedule"
+	schedule_expression = var.schedule_expression
+}
+
+data "aws_iam_policy_document" "events_assume" {
+	statement {
+		actions = ["sts:AssumeRole"]
+		principals {
+			type        = "Service"
+			identifiers = ["events.amazonaws.com"]
+		}
+	}
+}
+
+resource "aws_iam_role" "events_invoke" {
+	name               = "${var.project}-${var.env}-events-invoke"
+	assume_role_policy = data.aws_iam_policy_document.events_assume.json
+}
+
+data "aws_iam_policy_document" "events_run_task" {
+	statement {
+		sid       = "RunTask"
+		actions   = ["ecs:RunTask"]
+		# Allow running the current task definition revision (this updates automatically on new revision apply)
+		resources = [aws_ecs_task_definition.etl.arn]
+		condition {
+			test     = "ArnEquals"
+			variable = "ecs:cluster"
+			values   = [aws_ecs_cluster.etl.arn]
+		}
+	}
+	statement {
+		sid       = "PassRoles"
+		actions   = ["iam:PassRole"]
+		resources = [aws_iam_role.ecs_execution_role.arn, aws_iam_role.ecs_task_role.arn]
+	}
+}
+
+resource "aws_iam_policy" "events_run_task" {
+	name   = "${var.project}-${var.env}-events-run-task"
+	policy = data.aws_iam_policy_document.events_run_task.json
+}
+
+resource "aws_iam_role_policy_attachment" "events_run_task_attach" {
+	role       = aws_iam_role.events_invoke.name
+	policy_arn = aws_iam_policy.events_run_task.arn
+}
+
+resource "aws_cloudwatch_event_target" "etl" {
+	rule      = aws_cloudwatch_event_rule.etl_schedule.name
+	target_id = "${var.project}-${var.env}-etl-target"
+	arn       = aws_ecs_cluster.etl.arn
+	role_arn  = aws_iam_role.events_invoke.arn
+	ecs_target {
+		launch_type         = "FARGATE"
+		platform_version    = "LATEST"
+		task_definition_arn = aws_ecs_task_definition.etl.arn
+		enable_execute_command = false
+		network_configuration {
+			subnets          = data.aws_subnets.default.ids
+			security_groups  = [aws_security_group.etl_task.id]
+			assign_public_ip = true
+		}
+	}
+	depends_on = [aws_ecs_task_definition.etl, aws_iam_role.events_invoke]
+}
+
+
+# Outputs
+
+output "ecr_repo_url" { value = aws_ecr_repository.etl.repository_url }
+output "ecs_cluster_arn" { value = aws_ecs_cluster.etl.arn }
+output "task_definition_arn" { value = aws_ecs_task_definition.etl.arn }
+output "event_rule_name" { value = aws_cloudwatch_event_rule.etl_schedule.name }
+output "log_group" { value = aws_cloudwatch_log_group.etl.name }

--- a/infra/terraform/secrets.tf
+++ b/infra/terraform/secrets.tf
@@ -1,0 +1,46 @@
+# Secrets Manager handling for USAJOBS auth key.
+# Modes:
+# Existing secret (recommended): set var.usajobs_auth_secret_name and leave var.usajobs_auth_key empty.
+# Terraform uses a data source and does NOT manage the secret value.
+
+locals {
+  _want_secret          = var.usajobs_auth_secret_name != ""
+  _manage_secret_value  = local._want_secret && var.usajobs_auth_key != ""
+}
+
+# Data source for existing secret (created outside TF)
+data "aws_secretsmanager_secret" "usajobs_auth" {
+  count = local._want_secret && !local._manage_secret_value ? 1 : 0
+  name  = var.usajobs_auth_secret_name
+}
+
+# Managed secret resources (only if a key provided)
+resource "aws_secretsmanager_secret" "usajobs_auth" {
+  count       = local._manage_secret_value ? 1 : 0
+  name        = var.usajobs_auth_secret_name
+  description = "USAJOBS API auth key"
+  tags        = { project = var.project, env = var.env }
+}
+
+resource "aws_secretsmanager_secret_version" "usajobs_auth" {
+  count         = local._manage_secret_value ? 1 : 0
+  secret_id     = aws_secretsmanager_secret.usajobs_auth[0].id
+  secret_string = var.usajobs_auth_key
+}
+
+# Canonical secret ARN (resource or data)
+locals {
+  usajobs_auth_secret_arn = local._manage_secret_value ? aws_secretsmanager_secret.usajobs_auth[0].arn : (
+    local._want_secret ? data.aws_secretsmanager_secret.usajobs_auth[0].arn : ""
+  )
+}
+
+# DB URL secret (existing only; we don't manage value here)
+data "aws_secretsmanager_secret" "db_url" {
+  count = var.db_url_secret_name != "" ? 1 : 0
+  name  = var.db_url_secret_name
+}
+
+locals {
+  db_url_secret_arn = var.db_url_secret_name != "" ? data.aws_secretsmanager_secret.db_url[0].arn : ""
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -27,3 +27,83 @@ variable "bronze_bucket_name" {
   type        = string
   default     = null
 }
+
+# --- Added for ECS / scheduler deployment ---
+variable "schedule_expression" {
+  description = "EventBridge schedule (cron or rate)"
+  type        = string
+  default     = "cron(0 * * * ? *)"
+}
+
+variable "dq_enforce" {
+  description = "Enforce data quality gate"
+  type        = bool
+  default     = true
+}
+
+variable "bronze_prefix" {
+  description = "Bronze S3 prefix"
+  type        = string
+  default     = "bronze/usajobs"
+}
+
+variable "usajobs_user_agent" {
+  description = "USAJOBS registered email (User-Agent)"
+  type        = string
+}
+
+variable "usajobs_auth_key" {
+  description = "(DEPRECATED) Direct USAJOBS API auth key. Prefer secrets manager."
+  type        = string
+  default     = ""
+}
+
+variable "usajobs_auth_secret_name" {
+  description = "Secrets Manager secret name storing USAJOBS auth key"
+  type        = string
+  default     = "tasman/dev/usajobs/auth"
+}
+
+variable "db_url" {
+  description = "Database URL for Postgres"
+  type        = string
+  # Optional: if using Secrets Manager (db_url_secret_name) this can be left blank.
+  # Providing both a secret and this value will prefer the secret at runtime.
+  default     = ""
+}
+
+variable "db_url_secret_name" {
+  description = "Secrets Manager secret name containing full DB URL"
+  type        = string
+  default     = "tasman/dev/db/url"
+}
+
+variable "container_cpu" {
+  description = "Fargate task CPU units"
+  type        = number
+  default     = 512
+}
+
+variable "container_memory" {
+  description = "Fargate task memory (MB)"
+  type        = number
+  default     = 1024
+}
+
+variable "keyword" {
+  description = "Default search keyword"
+  type        = string
+  default     = "data"
+}
+
+variable "location_name" {
+  description = "Default location name"
+  type        = string
+  default     = "Chicago, Illinois"
+}
+
+variable "max_pages" {
+  description = "Max pages per run"
+  type        = number
+  default     = 1
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dev = [
   "mypy>=1.10", "ruff>=0.5.0",
   "pre-commit>=3.7",
   "types-requests",
-  "boto3-stubs[s3]>=1.34",
+  # "boto3-stubs[s3]>=1.34", 
   "types-urllib3",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,3 +72,6 @@ filterwarnings = [
   "ignore:`Number` field should not be instantiated.*:marshmallow.warnings.ChangedInMarshmallow4Warning",
 ]
 testpaths = ["tests"]
+markers = [
+  "integration: marks tests that perform database integration (deselect with '-m \"not integration\"')",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
   "python-dotenv>=1.0",             # local .env dev
   "boto3>=1.34",                    # S3 bronze (optional)
   "great-expectations>=0.18.0",     # data quality gate
-  "pandas>=1.5,<2.0",
+  "pandas>=1.5",
   "typing-extensions>=4.11",
 ]
 
@@ -58,7 +58,7 @@ select = ["E","F","I","B","UP","PIE","C4","SIM"]
 ignore = ["UP038"]
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.12"
 strict = false
 warn_unused_ignores = true
 mypy_path = "$MYPY_CONFIG_FILE_DIR/src"

--- a/src/tasman_etl/config.py
+++ b/src/tasman_etl/config.py
@@ -1,19 +1,65 @@
-from pydantic import Field
-from pydantic_settings import BaseSettings, SettingsConfigDict
+"""Environment configuration (production-ready, minimal).
+
+Loads a local ``.env`` once (dotenv) and exposes helpers for code needing
+configuration. A small cached ``Settings`` shim is retained for backwards
+compat / DI convenience (dropped easily later).
+"""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from typing import Any
+
+from dotenv import find_dotenv, load_dotenv
+
+_DEFAULT_DB_URL = "postgresql://postgres:localpw@localhost:5432/usajobs"
+_ENV_LOADED = False
 
 
-class Settings(BaseSettings):
-    # Toggle the Great Expectations Data Quality (DQ) checks
-    # True blocks on failure, False logs and continues
-    dq_enforce: bool = Field(
-        default=True,
-        validation_alias="DQ_ENFORCE",
-    )
-    # Database connection string for loader
-    db_url: str = Field(
-        default="postgresql://postgres:localpw@localhost:5432/usajobs",
-        validation_alias="DB_URL",
-    )
+def load_env(path: str = ".env", *, override: bool = False) -> None:
+    global _ENV_LOADED
+    if _ENV_LOADED:
+        return
+    # If explicit path missing, attempt discovery (walk upwards) for flexibility.
+    if not os.path.exists(path):  # pragma: no cover - defensive
+        discovered = find_dotenv(usecwd=True)
+        if discovered:
+            path = discovered
+    load_dotenv(path, override=override)
+    _ENV_LOADED = True
 
-    # (Optional) make local .env loading explicit; safe in containers too.
-    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
+
+def env(key: str, default: Any | None = None) -> Any:
+    load_env()
+    return os.getenv(key, default)
+
+
+def env_bool(key: str, default: bool = False) -> bool:
+    val = env(key)
+    if val is None:
+        return default
+    return str(val).lower() in {"1", "true", "yes", "on"}
+
+
+def db_url() -> str:
+    url = env("DB_URL", _DEFAULT_DB_URL)
+    if url.startswith("postgresql+psycopg://"):
+        url = url.replace("postgresql+psycopg://", "postgresql://", 1)
+    return url
+
+
+class Settings:  # pragma: no cover - compatibility shim
+    def __init__(self) -> None:
+        load_env()
+        self.dq_enforce: bool = env_bool("DQ_ENFORCE", True)
+        self.db_url: str = db_url()
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    return Settings()
+
+
+# Eager load: ensures simple scripts that import deep modules still have env.
+load_env()

--- a/src/tasman_etl/config.py
+++ b/src/tasman_etl/config.py
@@ -18,6 +18,12 @@ _ENV_LOADED = False
 
 
 def load_env(path: str = ".env", *, override: bool = False) -> None:
+    """
+    Load environment variables from a .env file.
+
+    :param path: The path to the .env file (default: .env)
+    :param override: Whether to override existing environment variables (default: False)
+    """
     global _ENV_LOADED
     if _ENV_LOADED:
         return
@@ -31,11 +37,23 @@ def load_env(path: str = ".env", *, override: bool = False) -> None:
 
 
 def env(key: str, default: Any | None = None) -> Any:
+    """
+    Get an environment variable, loading the .env file if necessary.
+
+    :param key: The environment variable key (required)
+    :param default: The default value to return if the variable is not set (optional)
+    """
     load_env()
     return os.getenv(key, default)
 
 
 def env_bool(key: str, default: bool = False) -> bool:
+    """
+    Get a boolean environment variable, loading the .env file if necessary.
+
+    :param key: The environment variable key (required)
+    :param default: The default value to return if the variable is not set (optional)
+    """
     val = env(key)
     if val is None:
         return default
@@ -43,6 +61,11 @@ def env_bool(key: str, default: bool = False) -> bool:
 
 
 def db_url() -> str:
+    """
+    Get the database URL, loading the .env file if necessary.
+
+    :return: The database URL
+    """
     url = env("DB_URL", _DEFAULT_DB_URL)
     if url.startswith("postgresql+psycopg://"):
         url = url.replace("postgresql+psycopg://", "postgresql://", 1)
@@ -51,6 +74,9 @@ def db_url() -> str:
 
 class Settings:  # pragma: no cover - compatibility shim
     def __init__(self) -> None:
+        """
+        Load environment variables from a .env file.
+        """
         load_env()
         self.dq_enforce: bool = env_bool("DQ_ENFORCE", True)
         self.db_url: str = db_url()

--- a/src/tasman_etl/db/engine.py
+++ b/src/tasman_etl/db/engine.py
@@ -23,19 +23,11 @@ def _load_db_url() -> str:
     """
     # Try pydantic-settings first (works with Settings class if `db_url` exists)
     try:
-        from tasman_etl.config import (
-            Settings,  # local import to avoid hard dependency at import-time
-        )
+        from tasman_etl.config import db_url as _db_url  # lightweight helper
 
-        settings = Settings()  # will read env vars automatically
-        db_url = getattr(settings, "db_url", None)
-        if isinstance(db_url, str) and db_url:
-            return db_url
+        return _db_url()
     except Exception:
-        # If Settings isn't present or doesn't define db_url, just use env/default
-        pass
-
-    return os.getenv("DB_URL", _DEFAULT_DB_URL)
+        return os.getenv("DB_URL", _DEFAULT_DB_URL)
 
 
 @dataclass(frozen=True)

--- a/src/tasman_etl/db/engine.py
+++ b/src/tasman_etl/db/engine.py
@@ -1,0 +1,82 @@
+"""
+A database engine for connecting to the PostgreSQL database.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+import psycopg
+from psycopg import conninfo
+
+# Default for local dev / docker-compose
+_DEFAULT_DB_URL = "postgresql://postgres:localpw@localhost:5432/usajobs"
+
+
+def _load_db_url() -> str:
+    """
+    Resolve the database URL from pydantic-settings if available,
+    otherwise fall back to the DB_URL env var (then a sensible default).
+
+    :return: The database URL.
+    """
+    # Try pydantic-settings first (works with Settings class if `db_url` exists)
+    try:
+        from tasman_etl.config import (
+            Settings,  # local import to avoid hard dependency at import-time
+        )
+
+        settings = Settings()  # will read env vars automatically
+        db_url = getattr(settings, "db_url", None)
+        if isinstance(db_url, str) and db_url:
+            return db_url
+    except Exception:
+        # If Settings isn't present or doesn't define db_url, just use env/default
+        pass
+
+    return os.getenv("DB_URL", _DEFAULT_DB_URL)
+
+
+@dataclass(frozen=True)
+class Engine:
+    """
+    Thin holder for a normalised DSN and a convenience connect() method.
+
+    Use:
+        from tasman_etl.db.engine import engine
+        with psycopg.connect(engine.dsn) as conn:
+            ...
+    or:
+        from tasman_etl.db.engine import engine
+        with engine.connect() as conn:
+            ...
+    """
+
+    dsn: str
+
+    def connect(self, **kwargs) -> psycopg.Connection:
+        """
+        Create a new database connection.
+
+        :return: A new database connection.
+        """
+        return psycopg.connect(self.dsn, **kwargs)
+
+
+def build_engine(app_name: str = "tasman_etl") -> Engine:
+    """
+    Normalise/augment the DSN via psycopg.conninfo to set things like application_name.
+
+    :param app_name: The application name to set in the connection (default: "tasman_etl").
+    :return: An Engine instance.
+    """
+    url = _load_db_url()
+    # conninfo.make_conninfo accepts either a URI or key=value string and merges options cleanly.
+    # (libpq/psycopg will accept both URI and DSN formats.)
+    dsn = conninfo.make_conninfo(url, application_name=app_name)
+    return Engine(dsn=dsn)
+
+
+# Singleton used across the app
+engine = build_engine()

--- a/src/tasman_etl/http/usajobs.py
+++ b/src/tasman_etl/http/usajobs.py
@@ -4,21 +4,30 @@ This module provides a client for the USAJOBS API.
 
 from __future__ import annotations
 
+import logging
 import os
+import random
 import time
 from typing import Any
 
 import requests
 
+logger = logging.getLogger("tasman.usajobs")
+
 
 class UsaJobsClient:
-    """
-    Minimal USAJOBS Search API client.
+    """USAJOBS Search API client (production focused).
 
-    Reads required headers from env:
-      - USAJOBS_HOST (default: data.usajobs.gov)
-      - USAJOBS_USER_AGENT (your email registered with USAJOBS)
-      - USAJOBS_AUTH_KEY (your API key)
+    Environment variables (unless explicitly passed):
+      * USAJOBS_HOST          (default: data.usajobs.gov)
+      * USAJOBS_USER_AGENT    (required – registered email)
+      * USAJOBS_AUTH_KEY      (required – API key)
+
+    Features:
+      * Explicit Accept header (vendor + JSON) to avoid empty bodies.
+      * Exponential backoff with jitter on network / HTTP >=500.
+      * Structured debug logging of attempts, latency, and headers.
+      * Raises RuntimeError on persistent empty/invalid JSON despite 200.
     """
 
     def __init__(
@@ -28,16 +37,16 @@ class UsaJobsClient:
         auth_key: str | None = None,
         base_url: str | None = None,
         timeout: float = 15.0,
+        accept: str | None = None,
     ) -> None:
-        """
-        Initialise the USAJOBS API client.
+        """Initialise the USAJOBS API client."""
+        try:  # load .env lazily if available
+            from tasman_etl.config import load_env
 
-        :param host: The API host (default: data.usajobs.gov)
-        :param user_agent: The User-Agent header value (default: USAJOBS_USER_AGENT env var)
-        :param auth_key: The Authorization-Key header value (default: USAJOBS_AUTH_KEY env var)
-        :param base_url: The base URL for API requests (default: https://{host}/api/search)
-        :param timeout: The request timeout in seconds (default: 15.0)
-        """
+            load_env()
+        except Exception:
+            pass
+
         self.host = host or os.getenv("USAJOBS_HOST", "data.usajobs.gov")
         self.user_agent = user_agent or os.getenv("USAJOBS_USER_AGENT")
         self.auth_key = auth_key or os.getenv("USAJOBS_AUTH_KEY")
@@ -50,9 +59,9 @@ class UsaJobsClient:
             )
 
         self._headers = {
-            "Host": self.host,
             "User-Agent": self.user_agent,
             "Authorization-Key": self.auth_key,
+            "Accept": accept or "application/hr+json, application/json;q=0.9, */*;q=0.8",
         }
 
     def fetch_search_page(
@@ -64,26 +73,11 @@ class UsaJobsClient:
         results_per_page: int = 50,
         page: int = 1,
         fields: str | None = None,  # "full" or "min"
-        retry: int = 2,
-        backoff_sec: float = 1.0,
+        retry: int = 3,
+        backoff_base: float = 0.75,
+        backoff_cap: float = 6.0,
     ) -> tuple[dict, dict]:
-        """
-        Fetch one page from the Search API and return:
-          request_dict: {"endpoint": "/api/search", "params": {...}}
-          response_dict: {"status": int, "headers": {..}, "payload": dict}
-
-        Shapes match what your bronze writer expects.
-
-        :param keyword: The search keyword.
-        :param location_name: The location name (optional).
-        :param radius_miles: The search radius in miles (optional).
-        :param results_per_page: The number of results per page (default: 50).
-        :param page: The page number (default: 1).
-        :param fields: The fields to include in the response (default: None).
-        :param retry: The number of retry attempts (default: 2).
-        :param backoff_sec: The backoff time in seconds (default: 1.0).
-        :return: A tuple of (request_dict, response_dict).
-        """
+        """Fetch one page from the Search API and return (request_dict, response_dict)."""
         params: dict[str, Any] = {
             "Keyword": keyword,
             "ResultsPerPage": results_per_page,
@@ -96,14 +90,11 @@ class UsaJobsClient:
         if fields:
             params["Fields"] = fields
 
-        request_dict = {
-            "endpoint": "/api/search",
-            "params": params,
-        }
+        request_dict = {"endpoint": "/api/search", "params": params}
 
-        # simple bounded retry
         last_exc: Exception | None = None
-        for attempt in range(retry + 1):
+        for attempt in range(1, retry + 2):  # attempts = retry + 1
+            start = time.perf_counter()
             try:
                 resp = requests.get(
                     self.base_url,
@@ -111,11 +102,42 @@ class UsaJobsClient:
                     params=params,
                     timeout=self.timeout,
                 )
-                payload = (
-                    resp.json()
-                    if resp.headers.get("Content-Type", "").startswith("application/json")
-                    else {}
+                latency = (time.perf_counter() - start) * 1000
+                content_type = resp.headers.get("Content-Type", "")
+
+                logger.debug(
+                    "usajobs.request",
+                    extra={
+                        "status": resp.status_code,
+                        "latency_ms": round(latency, 1),
+                        "attempt": attempt,
+                        "page": page,
+                        "results_per_page": results_per_page,
+                        "content_type": content_type,
+                        "rate_limit": {
+                            k: v
+                            for k, v in resp.headers.items()
+                            if k.lower().startswith("x-ratelimit")
+                        },
+                    },
                 )
+
+                if resp.status_code >= 500:
+                    raise RuntimeError(f"HTTP {resp.status_code} server error")
+
+                payload: dict[str, Any] = {}
+                if content_type.startswith("application/json") or "hr+json" in content_type:
+                    try:
+                        payload = resp.json() or {}
+                    except Exception as je:  # decode issue
+                        logger.warning("json.decode_failed", extra={"error": str(je)})
+
+                if resp.status_code == 200 and not payload:
+                    snippet = (resp.text or "")[:200]
+                    raise RuntimeError(
+                        f"empty_payload: status=200 ct={content_type} snippet={snippet!r}"
+                    )
+
                 response_dict = {
                     "status": resp.status_code,
                     "headers": {
@@ -126,13 +148,24 @@ class UsaJobsClient:
                     "payload": payload,
                 }
                 return request_dict, response_dict
-            except Exception as e:  # network/transient
+            except Exception as e:  # network / transient / empty payload / decode
                 last_exc = e
-                if attempt < retry:
-                    time.sleep(backoff_sec * (2**attempt))
-                else:
-                    raise
+                if attempt <= retry:
+                    delay = min(backoff_cap, backoff_base * (2 ** (attempt - 1)))
+                    jitter = delay * (0.4 * random.random() - 0.2)
+                    sleep_for = max(0.05, delay + jitter)
+                    logger.warning(
+                        "usajobs.retrying",
+                        extra={
+                            "attempt": attempt,
+                            "error": str(e),
+                            "sleep_s": round(sleep_for, 2),
+                        },
+                    )
+                    time.sleep(sleep_for)
+                    continue
+                break
 
-        # should never reach here
         assert last_exc is not None
+        logger.error("usajobs.failed", extra={"error": str(last_exc)})
         raise last_exc

--- a/src/tasman_etl/http/usajobs.py
+++ b/src/tasman_etl/http/usajobs.py
@@ -1,5 +1,5 @@
 """
-This module provides a client for the USAJOBS API.
+A client for the USAJOBS API.
 """
 
 from __future__ import annotations
@@ -39,7 +39,16 @@ class UsaJobsClient:
         timeout: float = 15.0,
         accept: str | None = None,
     ) -> None:
-        """Initialise the USAJOBS API client."""
+        """
+        Initialise the USAJOBS API client.
+
+        :param host: The API host (default: data.usajobs.gov)
+        :param user_agent: The User-Agent string (required)
+        :param auth_key: The API key (required)
+        :param base_url: The base URL for API requests (optional)
+        :param timeout: The request timeout in seconds (default: 15.0)
+        :param accept: The Accept header for API requests (optional)
+        """
         try:  # load .env lazily if available
             from tasman_etl.config import load_env
 
@@ -77,7 +86,20 @@ class UsaJobsClient:
         backoff_base: float = 0.75,
         backoff_cap: float = 6.0,
     ) -> tuple[dict, dict]:
-        """Fetch one page from the Search API and return (request_dict, response_dict)."""
+        """
+        Fetch one page from the Search API and return (request_dict, response_dict).
+
+        :param keyword: The search keyword (required)
+        :param location_name: The location name (optional)
+        :param radius_miles: The search radius in miles (optional)
+        :param results_per_page: The number of results per page (default: 50)
+        :param page: The page number to retrieve (default: 1)
+        :param fields: The fields to include in the response (optional)
+        :param retry: The number of retry attempts for transient errors (default: 3)
+        :param backoff_base: The base backoff time in seconds (default: 0.75)
+        :param backoff_cap: The maximum backoff time in seconds (default: 6.0)
+        :return: A tuple containing the request dictionary and the response dictionary
+        """
         params: dict[str, Any] = {
             "Keyword": keyword,
             "ResultsPerPage": results_per_page,

--- a/src/tasman_etl/http/usajobs.py
+++ b/src/tasman_etl/http/usajobs.py
@@ -1,0 +1,138 @@
+"""
+This module provides a client for the USAJOBS API.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any
+
+import requests
+
+
+class UsaJobsClient:
+    """
+    Minimal USAJOBS Search API client.
+
+    Reads required headers from env:
+      - USAJOBS_HOST (default: data.usajobs.gov)
+      - USAJOBS_USER_AGENT (your email registered with USAJOBS)
+      - USAJOBS_AUTH_KEY (your API key)
+    """
+
+    def __init__(
+        self,
+        host: str | None = None,
+        user_agent: str | None = None,
+        auth_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 15.0,
+    ) -> None:
+        """
+        Initialise the USAJOBS API client.
+
+        :param host: The API host (default: data.usajobs.gov)
+        :param user_agent: The User-Agent header value (default: USAJOBS_USER_AGENT env var)
+        :param auth_key: The Authorization-Key header value (default: USAJOBS_AUTH_KEY env var)
+        :param base_url: The base URL for API requests (default: https://{host}/api/search)
+        :param timeout: The request timeout in seconds (default: 15.0)
+        """
+        self.host = host or os.getenv("USAJOBS_HOST", "data.usajobs.gov")
+        self.user_agent = user_agent or os.getenv("USAJOBS_USER_AGENT")
+        self.auth_key = auth_key or os.getenv("USAJOBS_AUTH_KEY")
+        self.base_url = base_url or f"https://{self.host}/api/search"
+        self.timeout = timeout
+
+        if not self.user_agent or not self.auth_key:
+            raise RuntimeError(
+                "USAJOBS_USER_AGENT and USAJOBS_AUTH_KEY must be set in the environment"
+            )
+
+        self._headers = {
+            "Host": self.host,
+            "User-Agent": self.user_agent,
+            "Authorization-Key": self.auth_key,
+        }
+
+    def fetch_search_page(
+        self,
+        *,
+        keyword: str,
+        location_name: str | None = None,
+        radius_miles: int | None = None,
+        results_per_page: int = 50,
+        page: int = 1,
+        fields: str | None = None,  # "full" or "min"
+        retry: int = 2,
+        backoff_sec: float = 1.0,
+    ) -> tuple[dict, dict]:
+        """
+        Fetch one page from the Search API and return:
+          request_dict: {"endpoint": "/api/search", "params": {...}}
+          response_dict: {"status": int, "headers": {..}, "payload": dict}
+
+        Shapes match what your bronze writer expects.
+
+        :param keyword: The search keyword.
+        :param location_name: The location name (optional).
+        :param radius_miles: The search radius in miles (optional).
+        :param results_per_page: The number of results per page (default: 50).
+        :param page: The page number (default: 1).
+        :param fields: The fields to include in the response (default: None).
+        :param retry: The number of retry attempts (default: 2).
+        :param backoff_sec: The backoff time in seconds (default: 1.0).
+        :return: A tuple of (request_dict, response_dict).
+        """
+        params: dict[str, Any] = {
+            "Keyword": keyword,
+            "ResultsPerPage": results_per_page,
+            "Page": page,
+        }
+        if location_name:
+            params["LocationName"] = location_name
+        if radius_miles is not None:
+            params["Radius"] = radius_miles
+        if fields:
+            params["Fields"] = fields
+
+        request_dict = {
+            "endpoint": "/api/search",
+            "params": params,
+        }
+
+        # simple bounded retry
+        last_exc: Exception | None = None
+        for attempt in range(retry + 1):
+            try:
+                resp = requests.get(
+                    self.base_url,
+                    headers=self._headers,
+                    params=params,
+                    timeout=self.timeout,
+                )
+                payload = (
+                    resp.json()
+                    if resp.headers.get("Content-Type", "").startswith("application/json")
+                    else {}
+                )
+                response_dict = {
+                    "status": resp.status_code,
+                    "headers": {
+                        k: v
+                        for k, v in resp.headers.items()
+                        if k.lower().startswith("x-ratelimit") or k.lower() in {"content-type"}
+                    },
+                    "payload": payload,
+                }
+                return request_dict, response_dict
+            except Exception as e:  # network/transient
+                last_exc = e
+                if attempt < retry:
+                    time.sleep(backoff_sec * (2**attempt))
+                else:
+                    raise
+
+        # should never reach here
+        assert last_exc is not None
+        raise last_exc

--- a/src/tasman_etl/runner/run.py
+++ b/src/tasman_etl/runner/run.py
@@ -120,7 +120,7 @@ def ingest_search_page(
         "categories": 0,
         "grades": 0,
     }
-    with engine.connect() as conn:  # or `psycopg.connect(engine.dsn) as conn``
+    with engine.connect() as conn:  # or `psycopg.connect(engine.dsn) as conn`
         for b in bundles:
             # If using Pydantic for PageBundle in future, uncomment the line below
             # page_bundle = PageBundle(**b.model_dump())

--- a/src/tasman_etl/runner/run.py
+++ b/src/tasman_etl/runner/run.py
@@ -8,7 +8,7 @@ import logging
 from datetime import UTC, datetime
 from typing import TypedDict
 
-from tasman_etl.config import Settings
+from tasman_etl.config import get_settings
 from tasman_etl.db.engine import engine
 from tasman_etl.db.repository import PageBundle, upsert_page
 from tasman_etl.dq.gx.validate import validate_page_jobs
@@ -105,7 +105,7 @@ def ingest_search_page(
     jobs = [b.job for b in bundles]
     locs = [loc for b in bundles for loc in b.locations]
     vx = validate_page_jobs(jobs, locs)
-    settings = Settings()
+    settings = get_settings()
     enforce = settings.dq_enforce if dq_enforce is None else dq_enforce
     if enforce and not vx.passed:
         # Fail hard if gate is on

--- a/src/tasman_etl/runner/run.py
+++ b/src/tasman_etl/runner/run.py
@@ -1,4 +1,31 @@
+"""
+The main entry point and overall orchestration logic for the ETL process.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import TypedDict
+
+from tasman_etl.config import Settings
+from tasman_etl.db.engine import engine
+from tasman_etl.db.repository import PageBundle, upsert_page
+from tasman_etl.dq.gx.validate import validate_page_jobs
+from tasman_etl.http.usajobs import UsaJobsClient
+from tasman_etl.models import ApiResponse
 from tasman_etl.storage.bronze_s3 import bronze_key, put_json_gz, utc_now_iso
+from tasman_etl.transform import normalise_page
+
+logging.basicConfig(level=logging.INFO)
+
+
+class IngestStats(TypedDict):
+    bronze_key: str
+    jobs: int
+    locations: int
+    categories: int
+    grades: int
 
 
 def persist_raw_page(run_id: str, page: int, request_dict: dict, response_dict: dict) -> str:
@@ -24,3 +51,90 @@ def persist_raw_page(run_id: str, page: int, request_dict: dict, response_dict: 
     key = bronze_key(run_id, page)
     put_json_gz(key, envelope)
     return key
+
+
+def ingest_search_page(
+    *,
+    run_id: str,
+    page: int,
+    keyword: str,
+    location_name: str | None,
+    radius_miles: int | None,
+    results_per_page: int = 50,
+    fields: str | None = None,
+    dq_enforce: bool | None = None,  # override Settings() if desired
+) -> IngestStats:
+    """
+    End-to-end for one Search page:
+      1) fetch page (HTTP)
+      2) persist bronze
+      3) validate (GX)
+      4) normalise -> bundles
+      5) upsert into DB
+    Returns simple run stats.
+
+    :param run_id: The ID of the run.
+    :param page: The page number.
+    :param keyword: The search keyword.
+    :param location_name: The location name (optional).
+    :param radius_miles: The search radius in miles (optional).
+    :param results_per_page: The number of results per page (default: 50).
+    :param fields: The fields to include in the response (default: None).
+    :param dq_enforce: Whether to enforce data quality checks (default: None).
+    :return: A dictionary of run statistics.
+    """
+    # 1) fetch
+    client = UsaJobsClient()
+    request_dict, response_dict = client.fetch_search_page(
+        keyword=keyword,
+        location_name=location_name,
+        radius_miles=radius_miles,
+        results_per_page=results_per_page,
+        page=page,
+        fields=fields,
+    )
+
+    # 2) bronze
+    bronze_key_out = persist_raw_page(run_id, page, request_dict, response_dict)
+
+    # 3) parse & normalise
+    resp = ApiResponse.model_validate(response_dict["payload"])
+    bundles = normalise_page(resp, ingest_run_id=run_id, source_event_time=datetime.now(UTC))
+
+    # 4) validation (GX)
+    jobs = [b.job for b in bundles]
+    locs = [loc for b in bundles for loc in b.locations]
+    vx = validate_page_jobs(jobs, locs)
+    settings = Settings()
+    enforce = settings.dq_enforce if dq_enforce is None else dq_enforce
+    if enforce and not vx.passed:
+        # Fail hard if gate is on
+        failed = [r.name for r in vx.rules if not r.success]
+        raise RuntimeError(f"Validation failed (gate on). Failed rules: {failed}")
+
+    # 5) load
+    stats: IngestStats = {
+        "bronze_key": bronze_key_out,
+        "jobs": 0,
+        "locations": 0,
+        "categories": 0,
+        "grades": 0,
+    }
+    with engine.connect() as conn:  # or `psycopg.connect(engine.dsn) as conn``
+        for b in bundles:
+            # If using Pydantic for PageBundle in future, uncomment the line below
+            # page_bundle = PageBundle(**b.model_dump())
+            page_bundle = PageBundle(
+                job=b.job,
+                details=b.details,
+                locations=list(b.locations),  # ensure list (defensive copy)
+                categories=list(b.categories),
+                grades=list(b.grades),
+            )
+            upsert_page(conn, page_bundle)
+            stats["jobs"] += 1
+            stats["locations"] += len(b.locations)
+            stats["categories"] += len(b.categories)
+            stats["grades"] += len(b.grades)
+
+    return stats

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,9 +8,26 @@ from third-party libraries.
 from __future__ import annotations
 
 import logging
+import os
+
+
+def _auto_env():
+    """Load .env early for tests (idempotent)."""
+    try:
+        from tasman_etl.config import load_env  # lightweight helper
+
+        load_env()
+    except Exception:
+        pass
+
+    # Provide a localhost DB fallback if docker-compose 'db' host isn't exported
+    if not os.getenv("DB_URL"):
+        # Only set if absent so explicit exports win
+        os.environ["DB_URL"] = "postgresql://postgres:localpw@localhost:5432/usajobs"
 
 
 def pytest_configure(config):
+    _auto_env()
     # Create an isolated logger for our DQ smoke summaries.
     logger = logging.getLogger("dq.smoke")
     logger.setLevel(logging.INFO)

--- a/tests/integration/test_run_ingest_integration.py
+++ b/tests/integration/test_run_ingest_integration.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import os
+
+import psycopg
+import pytest
+from tasman_etl.runner import run as run_mod
+
+DB_URL = os.getenv("DB_URL", "postgresql://postgres:localpw@localhost:5432/usajobs")
+
+
+class _StubClient:
+    def __init__(self, position_id: str):
+        self.position_id = position_id
+
+    def fetch_search_page(self, **kwargs):  # same shape as real client output
+        payload = {
+            "LanguageCode": "EN",
+            "SearchResult": {
+                "SearchResultCount": 1,
+                "SearchResultCountAll": 1,
+                "SearchResultItems": [
+                    {
+                        "MatchedObjectId": f"MO-{self.position_id}",
+                        "MatchedObjectDescriptor": {
+                            "PositionID": self.position_id,
+                            "PositionTitle": "Integration Engineer",
+                            "PositionURI": f"https://example/job/{self.position_id}",
+                            "PositionLocation": [
+                                {"LocationName": "New York", "CityName": "New York"}
+                            ],
+                            "JobCategory": [{"Code": "2210", "Name": "IT"}],
+                            "JobGrade": [{"Code": "13"}],
+                        },
+                    }
+                ],
+            },
+        }
+        request_dict = {"endpoint": "/api/search", "params": kwargs}
+        response_dict = {"status": 200, "headers": {}, "payload": payload}
+        return request_dict, response_dict
+
+
+@pytest.fixture()
+def patch_client(monkeypatch):
+    def _factory(position_id: str):
+        stub = _StubClient(position_id)
+        monkeypatch.setattr(run_mod, "UsaJobsClient", lambda: stub)
+        return stub
+
+    return _factory
+
+
+@pytest.fixture(autouse=True)
+def mock_bronze(monkeypatch):
+    # Avoid real S3 interaction
+    store = {}
+
+    def _fake_put_json_gz(key: str, doc):
+        store[key] = doc
+        return {"mocked": True}
+
+    monkeypatch.setattr(run_mod, "put_json_gz", _fake_put_json_gz)
+    return store
+
+
+@pytest.fixture(autouse=True)
+def fast_validate(monkeypatch):
+    def _validate(jobs, locs):
+        return type("R", (), {"passed": True, "rules": []})()
+
+    monkeypatch.setattr(run_mod, "validate_page_jobs", _validate)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("pid", ["INT-1001", "INT-1002"])
+def test_ingest_search_page_integration_roundtrip(pid, patch_client):
+    patch_client(pid)
+    stats = run_mod.ingest_search_page(
+        run_id="int-run",
+        page=1,
+        keyword="data",
+        location_name=None,
+        radius_miles=None,
+        results_per_page=25,
+        fields=None,
+    )
+    assert stats["jobs"] == 1
+
+    # Verify DB row exists
+    with psycopg.connect(DB_URL) as conn, conn.cursor() as cur:
+        cur.execute("SELECT position_title FROM job WHERE position_id = %s", (pid,))
+        row = cur.fetchone()
+        assert row is not None, "Job not persisted"
+        assert "Engineer" in row[0]
+
+
+@pytest.mark.integration
+def test_ingest_search_page_idempotent(patch_client):
+    pid = "INT-IDEMP-1"
+    patch_client(pid)
+    run_mod.ingest_search_page(
+        run_id="idemp-run",
+        page=1,
+        keyword="data",
+        location_name=None,
+        radius_miles=None,
+    )
+
+    # Second ingest with modified title through new stub instance (simulate changed upstream)
+    class _StubClient2(_StubClient):
+        def fetch_search_page(self, **kwargs):
+            request_dict, response_dict = super().fetch_search_page(**kwargs)
+            response_dict["payload"]["SearchResult"]["SearchResultItems"][0][
+                "MatchedObjectDescriptor"
+            ]["PositionTitle"] = "Integration Engineer Senior"
+            return request_dict, response_dict
+
+    stub2 = _StubClient2(pid)
+    # Rebind to new stub2
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(run_mod, "UsaJobsClient", lambda: stub2)
+    run_mod.ingest_search_page(
+        run_id="idemp-run",
+        page=1,
+        keyword="data",
+        location_name=None,
+        radius_miles=None,
+    )
+
+    # Confirm still single row, updated title
+    with psycopg.connect(DB_URL) as conn, conn.cursor() as cur:
+        cur.execute("SELECT count(*), max(position_title) FROM job WHERE position_id = %s", (pid,))
+        row = cur.fetchone()
+        assert row is not None
+        assert row[0] == 1
+        assert "Senior" in row[1]

--- a/tests/unit/test_run_ingest.py
+++ b/tests/unit/test_run_ingest.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import types
+from typing import Any
+
+import pytest
+
+# Target module under test
+from tasman_etl.runner import run as run_mod
+
+
+class _StubClient:
+    def __init__(self):
+        self.calls: list[dict[str, Any]] = []
+
+    def fetch_search_page(self, **kwargs):  # signature used in run.ingest_search_page
+        self.calls.append(kwargs)
+        # Minimal valid API payload matching ApiResponse schema
+        payload = {
+            "LanguageCode": "EN",
+            "SearchResult": {
+                "SearchResultCount": 1,
+                "SearchResultCountAll": 1,
+                "SearchResultItems": [
+                    {
+                        "MatchedObjectId": "M1",
+                        "MatchedObjectDescriptor": {
+                            "PositionID": "PID-UNIT-1",
+                            "PositionTitle": "Data Engineer",
+                            "PositionURI": "https://example/job/1",
+                            "PositionLocation": [
+                                {"LocationName": "Chicago", "CityName": "Chicago"}
+                            ],
+                            "JobCategory": [{"Code": "2210", "Name": "IT"}],
+                            "JobGrade": [{"Code": "12"}],
+                        },
+                    }
+                ],
+            },
+        }
+        request_dict = {"endpoint": "/api/search", "params": kwargs}
+        response_dict = {"status": 200, "headers": {}, "payload": payload}
+        return request_dict, response_dict
+
+
+# (Unused placeholder previously for validator results; removed for clarity.)
+
+
+def _patch(monkeypatch, name: str, obj):
+    monkeypatch.setattr(run_mod, name, obj)
+
+
+@pytest.fixture()
+def stub_client(monkeypatch):
+    sc = _StubClient()
+    # Patch class name used inside ingest_search_page
+    monkeypatch.setattr(run_mod, "UsaJobsClient", lambda: sc)
+    return sc
+
+
+@pytest.fixture()
+def capture_bronze(monkeypatch):
+    store: dict[str, Any] = {}
+
+    def _fake_put(key: str, doc):  # emulate side effect capture
+        store[key] = doc
+        return {"mocked": True}
+
+    _patch(monkeypatch, "put_json_gz", _fake_put)
+    return store
+
+
+@pytest.fixture()
+def fake_upsert(monkeypatch):
+    calls: list[Any] = []
+
+    def _fake_upsert(conn, bundle, **kwargs):
+        calls.append(bundle)
+        return 42  # stable fake job_id
+
+    _patch(monkeypatch, "upsert_page", _fake_upsert)
+    return calls
+
+
+@pytest.fixture()
+def fake_validate(monkeypatch):
+    state = {"passed": True}
+
+    def _fake_validate(jobs, locs):
+        return types.SimpleNamespace(passed=state["passed"], rules=[])
+
+    _patch(monkeypatch, "validate_page_jobs", _fake_validate)
+    return state
+
+
+@pytest.fixture(autouse=True)
+def stub_engine(monkeypatch):
+    """Provide a stub engine so unit tests don't open real DB connections."""
+
+    class _StubConn:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):  # noqa: D401
+            return False  # don't suppress
+
+    class _StubEngine:
+        def connect(self, **kwargs):  # signature compatibility
+            return _StubConn()
+
+    monkeypatch.setattr(run_mod, "engine", _StubEngine())
+
+
+def test_ingest_search_page_happy(stub_client, capture_bronze, fake_upsert, fake_validate):
+    stats = run_mod.ingest_search_page(
+        run_id="rid-1",
+        page=1,
+        keyword="data",
+        location_name=None,
+        radius_miles=None,
+        results_per_page=50,
+        fields=None,
+    )
+    assert stats["jobs"] == 1
+    assert stats["locations"] == 1
+    assert stats["categories"] == 1
+    assert stats["grades"] == 1
+    assert len(fake_upsert) == 1
+    assert stub_client.calls, "Client should have been invoked"
+    assert any(key.endswith("page=0001.json.gz") for key in capture_bronze)
+
+
+def test_ingest_search_page_dq_gate_blocks(stub_client, capture_bronze, fake_upsert, fake_validate):
+    fake_validate["passed"] = False
+    with pytest.raises(RuntimeError):
+        run_mod.ingest_search_page(
+            run_id="rid-2",
+            page=1,
+            keyword="data",
+            location_name=None,
+            radius_miles=None,
+            dq_enforce=True,  # force gate on
+        )
+    # ensure we did not persist to DB (no upsert) when gate failed
+    assert not fake_upsert, "Upsert should not have occurred on failed DQ gate"
+
+
+def test_ingest_search_page_dq_gate_disabled(
+    stub_client, capture_bronze, fake_upsert, fake_validate
+):
+    fake_validate["passed"] = False
+    stats = run_mod.ingest_search_page(
+        run_id="rid-3",
+        page=1,
+        keyword="data",
+        location_name=None,
+        radius_miles=None,
+        dq_enforce=False,  # disable gate explicitly
+    )
+    # Should still load
+    assert stats["jobs"] == 1
+    assert fake_upsert, "Upsert should have occurred with gate disabled"


### PR DESCRIPTION
**Region:** `eu-west-2`
**AWS profile (local):** `tasman-dev`

## Summary

This PR wires the full USAJOBS → Bronze (S3) → Validate (GE) → Transform (Pydantic v2) → Load (Postgres upserts) path, then deploys it as a scheduled Fargate task via Terraform (ECR + ECS + EventBridge + CloudWatch Logs + IAM). It includes unit/integration tests and a DQ smoke harness.

## What’s included

### App code

* **HTTP client**: `src/tasman_etl/http/usajobs.py`

  * Required headers, robust Accept (`application/hr+json`), retries with jitter, structured debug logging, guard on “empty 200”.
* **Bronze writer**: `src/tasman_etl/storage/bronze_s3.py`

  * Deterministic gzip, SHA256 metadata, checksum validation via S3 put with `ChecksumAlgorithm=SHA256`.
* **Runner/orchestration**: `src/tasman_etl/runner/run.py`

  * `ingest_search_page(...)`: fetch → bronze → validate (GE) → normalise → DB upsert, returns page stats.
* **Data quality (GE)**: `src/tasman_etl/dq/gx/validate.py`

  * Cached public API context, idempotent pandas asset, expectations for non-null keys, URL regex, pay ranges, “≥1 location”.
* **DB**: `src/tasman_etl/db/repository.py` (idempotent upserts, full child replacement) and `engine.py` wrapper (DSN normalization).
* **Config helpers**: `src/tasman_etl/config.py`

  * Lightweight `.env` loader (`load_env`), `env_bool`, `db_url`, and `get_settings()`; eager load for tests.
* **Transforms/Models**: Pydantic v2 models and normalisers (existing, refined during this branch).

### Tests

* **Unit**: `tests/unit/test_run_ingest.py` (stubs for HTTP/DB/S3/GE; verifies gate on/off and counts).
* **Integration**: `tests/integration/test_run_ingest_integration.py` (real Postgres, mocked HTTP/S3).
* **Smoke DQ**: `tests/smoke/test_dq_smoke.py` (+ `tests/conftest.py` logging) and `Makefile` targets `dq`/`smoke`.

### Terraform (deployable now)

* ECR repo, ECS cluster & task def (Fargate X86\_64), CloudWatch log group.
* EventBridge scheduled rule → ECS `RunTask` target (public subnets in default VPC).
* S3 bronze bucket (pre-existing from earlier work), IAM roles/policies (execution + least-priv task), Secrets Manager integration:

  * `tasman/dev/usajobs/auth` (USAJOBS API key)
  * `tasman/dev/db/url` (Postgres URL)
* Variables for schedule, CPU/mem, bronze prefix, DQ gate, search params.

## Configuration / Env

* **Secrets (preferred via TaskDefinition.secrets):**

  * `USAJOBS_AUTH_KEY` (Secrets Manager)
  * `DB_URL` (Secrets Manager) — or set `var.db_url` if you *must* bypass secrets for dev
* **Plain env vars (TaskDefinition.environment):**

  * `USAJOBS_USER_AGENT` (required; prompt via `terraform apply`)
  * `BRONZE_S3_BUCKET`, `BRONZE_S3_PREFIX`
  * `DQ_ENFORCE` (default true)
  * `KEYWORD`, `LOCATION_NAME`, `MAX_PAGES` (page loop handled in app entrypoint you add next)
* **Local dev:** `.env` (see `.env.example`) + `make up` / `make test`.

## How to verify locally

```bash
# DB up & migrations for tests
make up         # docker compose (db + healthcheck)
make test       # runs db-migrate -> lint -> type -> unit -> integration
make dq         # quick DQ smoke; shows GE summary
```

## How to deploy & run in AWS (already applied)

```bash
# Build & push image (done once per change)
export AWS_REGION=eu-west-2 AWS_PROFILE=tasman-dev
REPO_URL=$(terraform -chdir=infra/terraform output -raw ecr_repo_url)
REGISTRY=${REPO_URL%%/*}
aws ecr get-login-password --region "$AWS_REGION" --profile "$AWS_PROFILE" \
  | docker login --username AWS --password-stdin "$REGISTRY"

# Tag & push
GIT_SHA=$(git rev-parse --short HEAD)
docker buildx build --platform linux/amd64 -t etl-temp:latest -f docker/Dockerfile --load .
docker tag etl-temp:latest "${REPO_URL}:latest"
docker tag etl-temp:latest "${REPO_URL}:${GIT_SHA}"
docker push "${REPO_URL}:latest"
docker push "${REPO_URL}:${GIT_SHA}"
```

Run one-off task & tail logs:

```bash
CLUSTER_ARN=$(terraform -chdir=infra/terraform output -raw ecs_cluster_arn)
TASK_DEF=$(terraform -chdir=infra/terraform output -raw task_definition_arn)
LOG_GROUP=$(terraform -chdir=infra/terraform output -raw log_group)

# Resolve SG + subnet from TF-created resources
SG_ID=$(aws ec2 describe-security-groups --filters Name=group-name,Values=tasman-task-dev-etl-sg \
  --query 'SecurityGroups[0].GroupId' --output text --region $AWS_REGION --profile $AWS_PROFILE)
VPC_ID=$(aws ec2 describe-security-groups --group-ids "$SG_ID" \
  --query 'SecurityGroups[0].VpcId' --output text --region $AWS_REGION --profile $AWS_PROFILE)
SUBNET_ID=$(aws ec2 describe-subnets --filters Name=vpc-id,Values="$VPC_ID" Name=default-for-az,Values=true \
  --query 'Subnets[0].SubnetId' --output text --region $AWS_REGION --profile $AWS_PROFILE)

TASK_ARN=$(aws ecs run-task --cluster "$CLUSTER_ARN" --launch-type FARGATE \
  --task-definition "$TASK_DEF" \
  --network-configuration "awsvpcConfiguration={subnets=[$SUBNET_ID],securityGroups=[$SG_ID],assignPublicIp=ENABLED}" \
  --region $AWS_REGION --profile $AWS_PROFILE \
  --query 'tasks[0].taskArn' --output text)

aws ecs describe-tasks --cluster "$CLUSTER_ARN" --tasks "$TASK_ARN" \
  --region $AWS_REGION --profile $AWS_PROFILE \
  --query 'tasks[0].{status:lastStatus,exit:containers[0].exitCode,reason:stoppedReason}'
aws logs tail "$LOG_GROUP" --since 15m --follow --region $AWS_REGION --profile $AWS_PROFILE
```

Check bronze:

```bash
aws s3 ls "s3://$(terraform -chdir=infra/terraform output -raw bronze_bucket)/bronze/usajobs/" \
  --recursive --region $AWS_REGION --profile $AWS_PROFILE
```

## Reviewer checklist

* [ ] GE gate fires correctly (set `DQ_ENFORCE=true|false` to test).
* [ ] DB upserts idempotent (`position_id` unique; re-run keeps 1 row and updates).
* [ ] Bronze objects appear with expected path and deterministic gzip.
* [ ] Logs in `/ecs/tasman-task-dev-etl` show request/latency + retries on transient failures.
* [ ] Task definition holds **secrets from Secrets Manager** (not plain env) for `USAJOBS_AUTH_KEY` and `DB_URL`.
* [ ] IAM task role limited to the bronze bucket & the two secret ARNs.

## Risks / caveats

* Currently deploying with `:latest`. **Recommendation:** switch TF to parameterised `image_tag` and pin to `GIT_SHA` per release.
* Default VPC + public IP for simplicity. Move to private subnets + NAT when hardening.
* GE suite kept intentionally lean to reduce brittleness.
* Make sure `USAJOBS_USER_AGENT`/`USAJOBS_AUTH_KEY` are valid; client now hard-fails on empty 200s with a helpful snippet.

## Follow-ups (not in this PR)

* Immutable image tag in TF (deploy by SHA).
* RDS Postgres provisioning + SSL.
* Structured JSON logs + CloudWatch alarms on `level=ERROR`.
* Bounded concurrency for paging (respecting rate limits).
* CI: build/push on tag, terraform plan/apply workflow.

---

## Changelog (concise)

* Add resilient HTTP client, orchestrator, bronze writer, GE gate.
* Implement Postgres idempotent upserts + transaction timeout.
* Terraform: ECR/ECS/EventBridge + IAM + secrets + logging.
* Tests: unit, integration, DQ smoke; Makefile targets for DX.
* Config: dotenv helpers; eager `.env` in tests; default `DB_URL`.